### PR TITLE
OPTIM divide the context manager overhead by 3 by skipping redundant dynlib load operations

### DIFF
--- a/benchmarks/bench_context_manager_overhead.py
+++ b/benchmarks/bench_context_manager_overhead.py
@@ -1,0 +1,28 @@
+import time
+from argparse import ArgumentParser
+from pprint import pprint
+from statistics import mean, stdev
+from threadpoolctl import get_threadpool_limits, threadpool_limits
+
+parser = ArgumentParser(description='Measure threadpool_limits call overhead.')
+parser.add_argument('--import', dest="packages", nargs='+',
+                    help='Python packages to import to load threadpool enabled'
+                         ' libraries.')
+parser.add_argument("--n-calls", type=int, default=100,
+                    help="Number of iterations")
+
+args = parser.parse_args()
+for package_name in args.packages:
+    __import__(package_name)
+
+pprint(get_threadpool_limits())
+
+timings = []
+for _ in range(args.n_calls):
+    t = time.time()
+    with threadpool_limits(limits=1):
+        pass
+    timings.append(time.time() - t)
+
+print(f"Overhead per call: {mean(timings) * 1000:.3f} "
+      f"+/-{stdev(timings) * 1000:.3f} ms")

--- a/threadpoolctl/_threadpool_limiters.py
+++ b/threadpoolctl/_threadpool_limiters.py
@@ -93,26 +93,27 @@ def _get_limit(prefix, user_api, limits):
 @_format_docstring(ALL_PREFIXES=ALL_PREFIXES, INTERNAL_APIS=ALL_INTERNAL_APIS)
 def _set_threadpool_limits(limits=None, user_api=None,
                            return_original_limits=False):
-    """Limit the maximal number of threads for threadpools in supported C-lib
+    """Limit the maximal number of threads for threadpools in supported libs
 
     Set the maximal number of threads that can be used in thread pools used in
-    the supported C-libraries to `limit`. This function works for libraries
-    that are already loaded in the interpreter and can be changed dynamically.
+    the supported native libraries to `limit`. This function works for
+    libraries that are already loaded in the interpreter and can be changed
+    dynamically.
 
     The `limits` parameter can be either an integer or a dict to specify the
     maximal number of thread that can be used in thread pools. If it is an
-    integer, sets the maximum number of thread to `limits` for each C-lib
-    selected by `user_api`. If it is a dictionary `{{key: max_threads}}`,
-    this function sets a custom maximum number of thread for each `key` which
-    can be either a `user_api` or a `prefix` for a specific library.
-    If None, this function does not do anything.
+    integer, sets the maximum number of thread to `limits` for each library
+    selected by `user_api`. If it is a dictionary `{{key: max_threads}}`, this
+    function sets a custom maximum number of thread for each `key` which can be
+    either a `user_api` or a `prefix` for a specific library. If None, this
+    function does not do anything.
 
-    The `user_api` parameter selects particular APIs of C-libs to limit. Used
-    only if `limits` is an int. If it is None, this function will apply to all
-    supported C-libs. If it is "blas", it will limit only BLAS supported C-libs
-    and if it is "openmp", only OpenMP supported C-libs will be limited. Note
-    that the latter can affect the number of threads used by the BLAS C-libs if
-    they rely on OpenMP.
+    The `user_api` parameter selects particular APIs of libraries to limit.
+    Used only if `limits` is an int. If it is None, this function will apply to
+    all supported libraries. If it is "blas", it will limit only BLAS supported
+    libraries and if it is "openmp", only OpenMP supported libraries will be
+    limited. Note that the latter can affect the number of threads used by the
+    BLAS libraries if they rely on OpenMP.
 
     Return a list with all the supported modules that have been found. Each
     module is represented by a dict with the following information:
@@ -207,8 +208,7 @@ def get_version(dynlib, internal_api):
 
 
 def _get_mkl_version(mkl_dynlib):
-    """Return the MKL version
-    """
+    """Return the MKL version"""
     res = ctypes.create_string_buffer(200)
     mkl_dynlib.mkl_get_version_string(res, 200)
 
@@ -447,23 +447,23 @@ class threadpool_limits:
     block.
 
     Set the maximal number of threads that can be used in thread pools used in
-    the supported C-libraries to `limit`. This function works for libraries
-    that are already loaded in the interpreter and can be changed dynamically.
+    the supported libraries to `limit`. This function works for libraries that
+    are already loaded in the interpreter and can be changed dynamically.
 
     The `limits` parameter can be either an integer or a dict to specify the
     maximal number of thread that can be used in thread pools. If it is an
-    integer, sets the maximum number of thread to `limits` for each C-lib
-    selected by `user_api`. If it is a dictionary `{{key: max_threads}}`,
-    this function sets a custom maximum number of thread for each `key` which
-    can be either a `user_api` or a `prefix` for a specific library.
-    If None, this function does not do anything.
+    integer, sets the maximum number of thread to `limits` for each library
+    selected by `user_api`. If it is a dictionary `{{key: max_threads}}`, this
+    function sets a custom maximum number of thread for each `key` which can be
+    either a `user_api` or a `prefix` for a specific library. If None, this
+    function does not do anything.
 
-    The `user_api` parameter selects particular APIs of C-libs to limit. Used
-    only if `limits` is an int. If it is None, this function will apply to all
-    supported C-libs. If it is "blas", it will limit only BLAS supported C-libs
-    and if it is "openmp", only OpenMP supported C-libs will be limited. Note
-    that the latter can affect the number of threads used by the BLAS C-libs if
-    they rely on OpenMP.
+    The `user_api` parameter selects particular APIs of libraries to limit.
+    Used only if `limits` is an int. If it is None, this function will apply to
+    all supported libraries. If it is "blas", it will limit only BLAS supported
+    libraries and if it is "openmp", only OpenMP supported libraries will be
+    limited. Note that the latter can affect the number of threads used by the
+    BLAS libraries if they rely on OpenMP.
     """
     def __init__(self, limits=None, user_api=None):
         if limits is not None:

--- a/threadpoolctl/_threadpool_limiters.py
+++ b/threadpoolctl/_threadpool_limiters.py
@@ -123,7 +123,12 @@ def _set_threadpool_limits(limits=None, user_api=None,
       - 'internal_api': internal API.s Possible values are {INTERNAL_APIS}.
       - 'module_path': path to the loaded module.
       - 'version': version of the library implemented (if available).
-      - 'n_thread': current thread limit.
+      - 'n_thread': current thread limit if return_original_limits is False or
+        the original limit if return_original_limits is True.
+      - 'set_num_threads': callable to set the maximum number of threads
+      - 'get_num_threads': callable to get the current number of threads
+      - 'dynlib': the instance of ctypes.CDLL use to access the dynamic
+        library.
     """
     if isinstance(limits, int) or limits is None:
         if user_api is None:
@@ -157,6 +162,7 @@ def _set_threadpool_limits(limits=None, user_api=None,
         n_thread = _get_limit(module['prefix'], module['user_api'], limits)
         if return_original_limits:
             module['n_thread'] = module['get_num_threads']()
+
         if n_thread is not None:
             set_func = module['set_num_threads']
             set_func(n_thread)

--- a/threadpoolctl/_threadpool_limiters.py
+++ b/threadpoolctl/_threadpool_limiters.py
@@ -475,6 +475,8 @@ class threadpool_limits:
         if limits is not None:
             self.original_limits = _set_threadpool_limits(
                 limits=limits, user_api=user_api, return_original_limits=True)
+        else:
+            self.original_limits = None
 
     def __enter__(self):
         pass
@@ -483,6 +485,6 @@ class threadpool_limits:
         self.unregister()
 
     def unregister(self):
-        if hasattr(self, "original_limits"):
+        if self.original_limits is not None:
             for module in self.original_limits:
                 module['set_num_threads'](module['n_thread'])

--- a/threadpoolctl/tests/test_threadpool_limits.py
+++ b/threadpoolctl/tests/test_threadpool_limits.py
@@ -57,8 +57,8 @@ def test_threadpool_limits(openblas_present, mkl_present, prefix):
 
 @pytest.mark.parametrize("user_api", (None, "blas", "openmp"))
 def test_set_threadpool_limits_apis(user_api):
-    # Check that the number of threads used by the multithreaded C-libs can be
-    # modified dynamically.
+    # Check that the number of threads used by the multithreaded libraries can
+    # be modified dynamically.
     if user_api is None:
         api_modules = ('blas', 'openmp')
     else:

--- a/threadpoolctl/tests/test_threadpool_limits.py
+++ b/threadpoolctl/tests/test_threadpool_limits.py
@@ -23,7 +23,7 @@ def test_threadpool_limits(openblas_present, mkl_present, prefix):
 
     prefix_found = len([1 for module in old_limits
                         if prefix == module['prefix']])
-    old_limits = {clib['prefix']: clib['n_thread'] for clib in old_limits}
+    old_limits = {dynlib['prefix']: dynlib['n_thread'] for dynlib in old_limits}
 
     if not prefix_found:
         have_mkl = len({'mkl_rt', 'libmkl_rt'}.intersection(old_limits)) > 0
@@ -36,19 +36,22 @@ def test_threadpool_limits(openblas_present, mkl_present, prefix):
 
     try:
         new_limits = _set_threadpool_limits(limits={prefix: 1})
-        new_limits = {clib['prefix']: clib['n_thread'] for clib in new_limits}
+        new_limits = {dynlib['prefix']: dynlib['n_thread']
+                      for dynlib in new_limits}
         assert new_limits[prefix] == 1
 
         threadpool_limits(limits={prefix: 3})
         new_limits = get_threadpool_limits()
-        new_limits = {clib['prefix']: clib['n_thread'] for clib in new_limits}
+        new_limits = {dynlib['prefix']: dynlib['n_thread']
+                      for dynlib in new_limits}
         assert new_limits[prefix] in (3, old_limits[prefix])
     finally:
         # Avoid having side effects in case of failures
         threadpool_limits(limits=old_limits)
 
     new_limits = get_threadpool_limits()
-    new_limits = {clib['prefix']: clib['n_thread'] for clib in new_limits}
+    new_limits = {dynlib['prefix']: dynlib['n_thread']
+                  for dynlib in new_limits}
     assert new_limits[prefix] == old_limits[prefix]
 
 
@@ -56,14 +59,14 @@ def test_threadpool_limits(openblas_present, mkl_present, prefix):
 def test_set_threadpool_limits_apis(user_api):
     # Check that the number of threads used by the multithreaded C-libs can be
     # modified dynamically.
-
     if user_api is None:
         api_modules = ('blas', 'openmp')
     else:
         api_modules = (user_api,)
 
     old_limits = get_threadpool_limits()
-    old_limits = {clib['prefix']: clib['n_thread'] for clib in old_limits}
+    old_limits = {dynlib['prefix']: dynlib['n_thread']
+                  for dynlib in old_limits}
 
     try:
         new_limits = _set_threadpool_limits(limits=1, user_api=user_api)
@@ -91,7 +94,6 @@ def test_set_threadpool_limits_apis(user_api):
 
 def test_set_threadpool_limits_bad_input():
     # Check that appropriate errors are raised for invalid arguments
-
     match = re.escape("user_api must be either in {} or None."
                       .format(ALL_USER_APIS))
     with pytest.raises(ValueError, match=match):
@@ -105,18 +107,19 @@ def test_set_threadpool_limits_bad_input():
 @pytest.mark.parametrize("user_api", (None, "blas", "openmp"))
 def test_thread_limit_context(user_api):
     # Tests the thread limits context manager
-
     if user_api is None:
         apis = ('blas', 'openmp')
     else:
         apis = (user_api,)
 
     old_limits = get_threadpool_limits()
-    old_limits = {clib['prefix']: clib['n_thread'] for clib in old_limits}
+    old_limits = {dynlib['prefix']: dynlib['n_thread']
+                  for dynlib in old_limits}
 
     with threadpool_limits(limits=None, user_api=user_api):
         limits = get_threadpool_limits()
-        limits = {clib['prefix']: clib['n_thread'] for clib in limits}
+        limits = {dynlib['prefix']: dynlib['n_thread']
+                  for dynlib in limits}
         assert limits == old_limits
 
     with threadpool_limits(limits=1, user_api=user_api):
@@ -131,7 +134,7 @@ def test_thread_limit_context(user_api):
                 assert module['n_thread'] == old_limits[module['prefix']]
 
     limits = get_threadpool_limits()
-    limits = {clib['prefix']: clib['n_thread'] for clib in limits}
+    limits = {dynlib['prefix']: dynlib['n_thread'] for dynlib in limits}
     assert limits == old_limits
 
 
@@ -140,7 +143,6 @@ def test_thread_limit_context(user_api):
 def test_openmp_limit_num_threads(n_threads):
     # checks that OpenMP effectively uses the number of threads requested by
     # the context manager
-
     from ._openmp_test_helper import check_openmp_n_threads
 
     old_num_threads = check_openmp_n_threads(100)
@@ -151,7 +153,6 @@ def test_openmp_limit_num_threads(n_threads):
 
 
 def test_shipped_openblas():
-
     libopenblas = [ctypes.CDLL(path) for path in libopenblas_paths]
 
     old_limits = [blas.openblas_get_num_threads() for blas in libopenblas]
@@ -167,7 +168,6 @@ def test_shipped_openblas():
 @pytest.mark.skipif(len(libopenblas_paths) < 2,
                     reason="need at least 2 shipped openblas library")
 def test_multiple_shipped_openblas():
-
     libopenblas = [ctypes.CDLL(path) for path in libopenblas_paths]
 
     old_limits = [blas.openblas_get_num_threads() for blas in libopenblas]


### PR DESCRIPTION
This should improve significantly the performance issue reported in #1.