### PR TITLE
Cache system libraries lookups

### DIFF
--- a/benchmarks/bench_context_manager_overhead.py
+++ b/benchmarks/bench_context_manager_overhead.py
@@ -24,5 +24,5 @@ for _ in range(args.n_calls):
         pass
     timings.append(time.time() - t)
 
-print(f"Overhead per call: {mean(timings) * 1000:.3f} "
-      f"+/-{stdev(timings) * 1000:.3f} ms")
+print(f"Overhead per call: {mean(timings) * 1e3:.3f} "
+      f"+/-{stdev(timings) * 1e3:.3f} ms")


### PR DESCRIPTION
The lookup to the libc under POSIX is actually dominating the overhead based on a profile report of the benchmark script.

Simply caching this removes most of the overhead:

- master:

```
$ python  benchmarks/bench_context_manager_overhead.py --n-calls 300 --import numpy scipy lightgbm
[{'filename_prefixes': ('libopenblas',),
  'internal_api': 'openblas',
  'module_path': '/opt/venvs/py37/lib/python3.7/site-packages/numpy/.libs/libopenblasp-r0-382c8f3a.3.5.dev.so',
  'n_thread': 4,
  'prefix': 'libopenblas',
  'user_api': 'blas',
  'version': '0.3.5.dev'},
 {'filename_prefixes': ('libopenblas',),
  'internal_api': 'openblas',
  'module_path': '/opt/venvs/py37/lib/python3.7/site-packages/scipy/.libs/libopenblasp-r0-8dca6697.3.0.dev.so',
  'n_thread': 4,
  'prefix': 'libopenblas',
  'user_api': 'blas',
  'version': None},
 {'filename_prefixes': ('libiomp', 'libgomp', 'libomp', 'vcomp'),
  'internal_api': 'openmp',
  'module_path': '/usr/lib/x86_64-linux-gnu/libgomp.so.1',
  'n_thread': 4,
  'prefix': 'libgomp',
  'user_api': 'openmp',
  'version': None}]
Overhead per call: 8.523 +/-0.252 ms
```

- the branch of this PR:

```
$ python  benchmarks/bench_context_manager_overhead.py --n-calls 300 --import numpy scipy lightgbm
[{'filename_prefixes': ('libopenblas',),
  'internal_api': 'openblas',
  'module_path': '/opt/venvs/py37/lib/python3.7/site-packages/numpy/.libs/libopenblasp-r0-382c8f3a.3.5.dev.so',
  'n_thread': 4,
  'prefix': 'libopenblas',
  'user_api': 'blas',
  'version': '0.3.5.dev'},
 {'filename_prefixes': ('libopenblas',),
  'internal_api': 'openblas',
  'module_path': '/opt/venvs/py37/lib/python3.7/site-packages/scipy/.libs/libopenblasp-r0-8dca6697.3.0.dev.so',
  'n_thread': 4,
  'prefix': 'libopenblas',
  'user_api': 'blas',
  'version': None},
 {'filename_prefixes': ('libiomp', 'libgomp', 'libomp', 'vcomp'),
  'internal_api': 'openmp',
  'module_path': '/usr/lib/x86_64-linux-gnu/libgomp.so.1',
  'n_thread': 4,
  'prefix': 'libgomp',
  'user_api': 'openmp',
  'version': None}]
Overhead per call: 0.864 +/-0.240 ms
```