### PR TITLE
[MRG] make it possible to protect against oversubsription for various threadpool nesting cases

### DIFF
--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -67,5 +67,3 @@ jobs:
       pylatest_conda:
         PACKAGER: 'conda'
         VERSION_PYTHON: '*'
-        CC_OUTER_LOOP: 'gcc-8'
-        CC_INNER_LOOP: 'gcc-8'

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -67,3 +67,8 @@ jobs:
       pylatest_conda:
         PACKAGER: 'conda'
         VERSION_PYTHON: '*'
+        CC: '/usr/bin/clang'
+        CPPFLAGS: "-Xpreprocessor -fopenmp"
+        CFLAGS: "-I/usr/local/opt/libomp/include"
+        LDFLAGS: "-L/usr/local/opt/libomp/lib -lomp"
+        DYLD_LIBRARY_PATH: /usr/local/opt/libomp/lib

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -32,13 +32,20 @@ jobs:
     matrix:
       # Linux environment to test that packages that comes with Ubuntu Xenial
       # 16.04 are correctly handled.
-      py35_np_atlas:
+      py35_ubuntu_atlas_gcc_gcc:
         PACKAGER: 'ubuntu'
+        APT_BLAS: 'libatlas3-base libatlas-base-dev libatlas-dev'
+        VERSION_PYTHON: '3.5'
+        CC_OUTER_LOOP: 'gcc'
+        CC_INNER_LOOP: 'gcc'
+      py35_ubuntu_openblas_gcc_gcc:
+        PACKAGER: 'ubuntu'
+        APT_BLAS: 'libopenblas-base libopenblas-dev'
         VERSION_PYTHON: '3.5'
         CC_OUTER_LOOP: 'gcc'
         CC_INNER_LOOP: 'gcc'
       # Linux + Python 3.6 and homogeneous runtime nesting.
-      py36_conda_openblas:
+      py36_conda_openblas_clang_clang:
         PACKAGER: 'conda'
         VERSION_PYTHON: '3.6'
         NO_MKL: 'true'
@@ -46,14 +53,21 @@ jobs:
         CC_INNER_LOOP: 'clang-8'
       # Linux environment to test the latest available dependencies and MKL.
       # and heterogeneous OpenMP runtime nesting.
-      pylatest_conda:
+      pylatest_conda_mkl_clang_gcc:
         PACKAGER: 'conda'
         VERSION_PYTHON: '*'
         CC_OUTER_LOOP: 'clang-8'
         CC_INNER_LOOP: 'gcc'
+      # Same but with numpy / scipy installed with pip from PyPI and switched
+      # compilers.
+      pylatest_pip_openblas_gcc_clang:
+        PACKAGER: 'pip'
+        VERSION_PYTHON: '*'
+        CC_OUTER_LOOP: 'gcc'
+        CC_INNER_LOOP: 'clang-8'
       # Linux environment with no numpy and heterogeneous OpenMP runtime
       # nesting.
-      pylatest_conda_nonumpy:
+      pylatest_conda_nonumpy_gcc_clang:
         PACKAGER: 'conda'
         NO_NUMPY: 'true'
         VERSION_PYTHON: '*'

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -41,14 +41,14 @@ jobs:
       py36_conda_openblas:
         PACKAGER: 'conda'
         VERSION_PYTHON: '3.6'
-        CC_OUTER_LOOP: 'clang-6.0'
-        CC_INNER_LOOP: 'clang-6.0'
+        CC_OUTER_LOOP: 'clang-8'
+        CC_INNER_LOOP: 'clang-8'
       # Linux environment to test the latest available dependencies and MKL.
       # and heterogeneous OpenMP runtime nesting.
       pylatest_conda:
         PACKAGER: 'conda'
         VERSION_PYTHON: '*'
-        CC_OUTER_LOOP: 'clang-6.0'
+        CC_OUTER_LOOP: 'clang-8'
         CC_INNER_LOOP: 'gcc'
       # Linux environment with no numpy and heterogeneous OpenMP runtime
       # nesting.
@@ -57,7 +57,7 @@ jobs:
         NO_NUMPY: 'true'
         VERSION_PYTHON: '*'
         CC_OUTER_LOOP: 'gcc'
-        CC_INNER_LOOP: 'clang-6.0'
+        CC_INNER_LOOP: 'clang-8'
 
 - template: continuous_integration/posix.yml
   parameters:

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -67,8 +67,5 @@ jobs:
       pylatest_conda:
         PACKAGER: 'conda'
         VERSION_PYTHON: '*'
-        CC: '/usr/bin/clang'
-        CPPFLAGS: "-Xpreprocessor -fopenmp"
-        CFLAGS: "-I/usr/local/opt/libomp/include"
-        LDFLAGS: "-L/usr/local/opt/libomp/lib -lomp"
-        DYLD_LIBRARY_PATH: /usr/local/opt/libomp/lib
+        CC_OUTER_LOOP: 'gcc-8'
+        CC_INNER_LOOP: 'gcc-8'

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -41,6 +41,7 @@ jobs:
       py36_conda_openblas:
         PACKAGER: 'conda'
         VERSION_PYTHON: '3.6'
+        NO_MKL: 'true'
         CC_OUTER_LOOP: 'clang-8'
         CC_INNER_LOOP: 'clang-8'
       # Linux environment to test the latest available dependencies and MKL.

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -41,14 +41,14 @@ jobs:
       py36_conda_openblas:
         PACKAGER: 'conda'
         VERSION_PYTHON: '3.6'
-        CC_OUTER_LOOP: 'clang-8'
-        CC_INNER_LOOP: 'clang-8'
+        CC_OUTER_LOOP: 'clang-6.0'
+        CC_INNER_LOOP: 'clang-6.0'
       # Linux environment to test the latest available dependencies and MKL.
       # and heterogeneous OpenMP runtime nesting.
       pylatest_conda:
         PACKAGER: 'conda'
         VERSION_PYTHON: '*'
-        CC_OUTER_LOOP: 'clang-8'
+        CC_OUTER_LOOP: 'clang-6.0'
         CC_INNER_LOOP: 'gcc'
       # Linux environment with no numpy and heterogeneous OpenMP runtime
       # nesting.
@@ -57,7 +57,7 @@ jobs:
         NO_NUMPY: 'true'
         VERSION_PYTHON: '*'
         CC_OUTER_LOOP: 'gcc'
-        CC_INNER_LOOP: 'clang-8'
+        CC_INNER_LOOP: 'clang-6.0'
 
 - template: continuous_integration/posix.yml
   parameters:

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -41,14 +41,14 @@ jobs:
       py36_conda_openblas:
         PACKAGER: 'conda'
         VERSION_PYTHON: '3.6'
-        CC_OUTER_LOOP: 'clang-7'
-        CC_INNER_LOOP: 'clang-7'
+        CC_OUTER_LOOP: 'clang-8'
+        CC_INNER_LOOP: 'clang-8'
       # Linux environment to test the latest available dependencies and MKL.
       # and heterogeneous OpenMP runtime nesting.
       pylatest_conda:
         PACKAGER: 'conda'
         VERSION_PYTHON: '*'
-        CC_OUTER_LOOP: 'clang-7'
+        CC_OUTER_LOOP: 'clang-8'
         CC_INNER_LOOP: 'gcc'
       # Linux environment with no numpy and heterogeneous OpenMP runtime
       # nesting.
@@ -57,7 +57,7 @@ jobs:
         NO_NUMPY: 'true'
         VERSION_PYTHON: '*'
         CC_OUTER_LOOP: 'gcc'
-        CC_INNER_LOOP: 'clang-7'
+        CC_INNER_LOOP: 'clang-8'
 
 - template: continuous_integration/posix.yml
   parameters:

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -67,3 +67,5 @@ jobs:
       pylatest_conda:
         PACKAGER: 'conda'
         VERSION_PYTHON: '*'
+        CC_OUTER_LOOP: 'clang'
+        CC_INNER_LOOP: 'clang'

--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ with threadpool_limits(limits=1, user_api='blas'):
     a_squared = a @ a
 ```
 
+### Known limitation
+
+`threadpool_limits` does not act as expected in nested parallel loops
+managed by distinct OpenMP runtime implementations (for instance libgomp
+from GCC and libomp from clang/llvm or libiomp from ICC).
+
+See the `test_openmp_nesting()` function in `tests/test_threadpoolctl.py`
+for an example.
+
 ## Maintainers
 
 To make a release:

--- a/continuous_integration/build_test_ext.sh
+++ b/continuous_integration/build_test_ext.sh
@@ -7,4 +7,3 @@ rm -rf *.c *.so *.dylib build/
 python setup_inner.py build_ext -i
 python setup_outer.py build_ext -i
 popd
-

--- a/continuous_integration/build_test_ext.sh
+++ b/continuous_integration/build_test_ext.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+
+set -e
 
 pushd tests/_openmp_test_helper
 rm -rf *.c *.so *.dylib build/

--- a/continuous_integration/build_test_ext.sh
+++ b/continuous_integration/build_test_ext.sh
@@ -1,10 +1,7 @@
 
 pushd tests/_openmp_test_helper
-rm -f *.so *.dylib
-python setup.py build_ext -i
+rm -rf *.c *.so *.dylib build/
+python setup_inner.py build_ext -i
+python setup_outer.py build_ext -i
 popd
 
-pushd tests/_openmp_test_helper_outer
-rm -f *.so *.dylib
-python setup.py build_ext -i
-popd

--- a/continuous_integration/build_test_ext.sh
+++ b/continuous_integration/build_test_ext.sh
@@ -6,4 +6,9 @@ pushd tests/_openmp_test_helper
 rm -rf *.c *.so *.dylib build/
 python setup_inner.py build_ext -i
 python setup_outer.py build_ext -i
+
+# skip scipy required extension if no numpy
+if [[ "$NO_NUMPY" != "true" ]]; then
+    python setup_nested_prange_blas.py build_ext -i
+fi
 popd

--- a/continuous_integration/display_versions.py
+++ b/continuous_integration/display_versions.py
@@ -1,4 +1,3 @@
-from tests._openmp_test_helper import *
 from threadpoolctl import threadpool_info
 from pprint import pprint
 
@@ -12,6 +11,11 @@ try:
     import scipy
     import scipy.linalg
     print("scipy", scipy.__version__)
+except ImportError:
+    pass
+
+try:
+    from tests._openmp_test_helper import *  # noqa
 except ImportError:
     pass
 

--- a/continuous_integration/display_versions.py
+++ b/continuous_integration/display_versions.py
@@ -1,0 +1,19 @@
+from tests._openmp_test_helper import *
+from threadpoolctl import threadpool_info
+from pprint import pprint
+
+try:
+    import numpy as np
+    print("numpy", np.__version__)
+except ImportError:
+    pass
+
+try:
+    import scipy
+    import scipy.linalg
+    print("scipy", scipy.__version__)
+except ImportError:
+    pass
+
+
+pprint(threadpool_info())

--- a/continuous_integration/install.cmd
+++ b/continuous_integration/install.cmd
@@ -18,7 +18,7 @@ python --version
 pip --version
 
 @rem Install dependencies with either conda or pip.
-if "%PACKAGER%" == "conda" (%CONDA_INSTALL% numpy=1.15 pytest cython)
+if "%PACKAGER%" == "conda" (%CONDA_INSTALL% numpy=1.15 scipy pytest cython)
 if "%PACKAGER%" == "pip" (%PIP_INSTALL% numpy scipy pytest cython)
 
 @rem Install extra developer dependencies

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -7,7 +7,7 @@ UNAMESTR=`uname`
 if [[ "$UNAMESTR" == "Darwin" ]]; then
     # Install a compiler with a working openmp
     HOMEBREW_NO_AUTO_UPDATE=1 brew install libomp
-    
+
     # enable OpenMP support for Apple-clang
     export CC=/usr/bin/clang
     export CXX=/usr/bin/clang++
@@ -17,7 +17,7 @@ if [[ "$UNAMESTR" == "Darwin" ]]; then
     export LDFLAGS="$LDFLAGS -L/usr/local/opt/libomp/lib -lomp"
     export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib
 
-else
+elif [[ "$CC_OUTER_LOOP" == "clang-8" || "$CC_INNER_LOOP" == "clang-8" ]]
     # Assume Ubuntu: install a recent version of clang and libomp
     echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
     echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -5,8 +5,10 @@ set -e
 UNAMESTR=`uname`
 
 if [[ "$UNAMESTR" == "Darwin" ]]; then
-    # Install gcc on macOS to get a compiler with a working openmp
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install gcc@8
+    # Install a compiler with a working openmp
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install llvm libomp
+    export CC="$(brew --prefix llvm)/bin/clang"
+    export LDSHARED="$(brew --prefix llvm)/bin/clang -shared"
 else
     # Assume Ubuntu: install a recent version of clang and libomp
     echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -30,7 +30,6 @@ sudo apt install gdb
 
 make_conda() {
     TO_INSTALL="$@"
-    source /usr/share/miniconda/etc/profile.d/conda.sh
     conda create -n $VIRTUALENV -q --yes $TO_INSTALL
     conda activate $VIRTUALENV
 }

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -6,10 +6,16 @@ UNAMESTR=`uname`
 
 if [[ "$UNAMESTR" == "Darwin" ]]; then
     # Install a compiler with a working openmp
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install llvm libomp
-    export PATH="/usr/local/opt/llvm/bin:$PATH"
-    export LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
-    export CPPFLAGS="-I/usr/local/opt/llvm/include"
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install libomp
+    
+    # enable OpenMP support for Apple-clang
+    export CC=/usr/bin/clang
+    export CXX=/usr/bin/clang++
+    export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"
+    export CFLAGS="$CFLAGS -I/usr/local/opt/libomp/include"
+    export CXXFLAGS="$CXXFLAGS -I/usr/local/opt/libomp/include"
+    export LDFLAGS="$LDFLAGS -L/usr/local/opt/libomp/lib -lomp"
+    export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib
 
 else
     # Assume Ubuntu: install a recent version of clang and libomp
@@ -29,7 +35,7 @@ make_conda() {
 if [[ "$PACKAGER" == "conda" ]]; then
     TO_INSTALL="python=$VERSION_PYTHON pip pytest pytest-cov cython"
     if [[ "$NO_NUMPY" != "true" ]]; then
-         TO_INSTALL="$TO_INSTALL numpy"
+         TO_INSTALL="$TO_INSTALL numpy scipy"
     fi
 	make_conda $TO_INSTALL
 

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -18,12 +18,11 @@ if [[ "$UNAMESTR" == "Darwin" ]]; then
     export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib
 else
     # Assume Ubuntu: install a recent version of clang and libomp
-    # echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
-    # echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
-    # wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-    # sudo apt update
-    # sudo apt install clang-8 libomp-8-dev
-    echo "Using preinstalled clang-6.0 / libomp-dev"
+    echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
+    echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+    sudo apt update
+    sudo apt install clang-8 libomp-8-dev
 fi
 
 make_conda() {

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -19,11 +19,11 @@ if [[ "$UNAMESTR" == "Darwin" ]]; then
 else
     # Assume Ubuntu: install a recent version of clang and libomp to avoid a
     # deadlock when used in conjunction with Intel libiomp.
-    echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
-    echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
+    echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
+    echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
     sudo apt update
-    sudo apt install clang-7 libomp-7-dev
+    sudo apt install clang-8 libomp-8-dev
 fi
 
 make_conda() {

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -17,7 +17,7 @@ if [[ "$UNAMESTR" == "Darwin" ]]; then
     export LDFLAGS="$LDFLAGS -L/usr/local/opt/libomp/lib -lomp"
     export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib
 
-elif [[ "$CC_OUTER_LOOP" == "clang-8" || "$CC_INNER_LOOP" == "clang-8" ]]
+elif [[ "$CC_OUTER_LOOP" == "clang-8" || "$CC_INNER_LOOP" == "clang-8" ]]; then
     # Assume Ubuntu: install a recent version of clang and libomp
     echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
     echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
@@ -35,7 +35,10 @@ make_conda() {
 if [[ "$PACKAGER" == "conda" ]]; then
     TO_INSTALL="python=$VERSION_PYTHON pip pytest pytest-cov cython"
     if [[ "$NO_NUMPY" != "true" ]]; then
-         TO_INSTALL="$TO_INSTALL numpy scipy"
+        TO_INSTALL="$TO_INSTALL numpy scipy"
+        if [[ "$NO_MKL" == "true" ]]; then
+            TO_INSTALL="$TO_INSTALL nomkl"
+        fi
     fi
 	make_conda $TO_INSTALL
 

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -5,8 +5,8 @@ set -e
 UNAMESTR=`uname`
 
 if [[ "$UNAMESTR" == "Darwin" ]]; then
-    # install OpenMP not present by default on osx
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install libomp
+    # Install gcc on macOS to get a compiler with a working openmp
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install gcc@8
 
     # enable OpenMP support for Apple-clang
     export CC=/usr/bin/clang

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -35,7 +35,7 @@ make_conda() {
 }
 
 if [[ "$PACKAGER" == "conda" ]]; then
-    TO_INSTALL="python=$VERSION_PYTHON pip pytest pytest-cov cython"
+    TO_INSTALL="python=$VERSION_PYTHON pip"
     if [[ "$NO_NUMPY" != "true" ]]; then
         TO_INSTALL="$TO_INSTALL numpy scipy"
         if [[ "$NO_MKL" == "true" ]]; then
@@ -44,8 +44,17 @@ if [[ "$PACKAGER" == "conda" ]]; then
     fi
 	make_conda $TO_INSTALL
 
+elif [[ "$PACKAGER" == "pip" ]]; then
+    # Use conda to build an empty python env and then use pip to install
+    # numpy and scipy
+    TO_INSTALL="python=$VERSION_PYTHON pip"
+    make_conda $TO_INSTALL
+    if [[ "$NO_NUMPY" != "true" ]]; then
+        pip install numpy scipy
+    fi
+
 elif [[ "$PACKAGER" == "ubuntu" ]]; then
-    sudo apt-get install python3-scipy libatlas3-base libatlas-base-dev libatlas-dev libopenblas-base python3-virtualenv
+    sudo apt-get install python3-scipy python3-virtualenv $APT_BLAS
     python3 -m virtualenv --system-site-packages --python=python3 $VIRTUALENV
     source $VIRTUALENV/bin/activate
 fi

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -7,6 +7,10 @@ UNAMESTR=`uname`
 if [[ "$UNAMESTR" == "Darwin" ]]; then
     # Install a compiler with a working openmp
     HOMEBREW_NO_AUTO_UPDATE=1 brew install llvm libomp
+    export PATH="/usr/local/opt/llvm/bin:$PATH"
+    export LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
+    export CPPFLAGS="-I/usr/local/opt/llvm/include"
+
 else
     # Assume Ubuntu: install a recent version of clang and libomp
     echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -30,9 +30,8 @@ sudo apt install gdb
 
 make_conda() {
     TO_INSTALL="$@"
-    source /usr/share/miniconda/etc/profile.d/conda.sh
     conda create -n $VIRTUALENV -q --yes $TO_INSTALL
-    conda activate $VIRTUALENV
+    source activate $VIRTUALENV
 }
 
 if [[ "$PACKAGER" == "conda" ]]; then

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -31,7 +31,7 @@ sudo apt install gdb
 make_conda() {
     TO_INSTALL="$@"
     conda create -n $VIRTUALENV -q --yes $TO_INSTALL
-    source activate $VIRTUALENV
+    conda activate $VIRTUALENV
 }
 
 if [[ "$PACKAGER" == "conda" ]]; then

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -26,8 +26,6 @@ elif [[ "$CC_OUTER_LOOP" == "clang-8" || "$CC_INNER_LOOP" == "clang-8" ]]; then
     sudo apt install clang-8 libomp-8-dev
 fi
 
-sudo apt install gdb
-
 make_conda() {
     TO_INSTALL="$@"
     conda create -n $VIRTUALENV -q --yes $TO_INSTALL

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -52,6 +52,9 @@ elif [[ "$PACKAGER" == "pip" ]]; then
     fi
 
 elif [[ "$PACKAGER" == "ubuntu" ]]; then
+    # Remove the ubuntu toolchain PPA that seems to be invalid:
+    # https://github.com/scikit-learn/scikit-learn/pull/13934
+    sudo add-apt-repository --remove ppa:ubuntu-toolchain-r/test
     sudo apt-get install python3-scipy python3-virtualenv $APT_BLAS
     python3 -m virtualenv --system-site-packages --python=python3 $VIRTUALENV
     source $VIRTUALENV/bin/activate

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -5,10 +5,9 @@ set -e
 UNAMESTR=`uname`
 
 if [[ "$UNAMESTR" == "Darwin" ]]; then
+    echo "macOS detected"
     # Install a compiler with a working openmp
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install llvm libomp
-    export CC="$(brew --prefix llvm)/bin/clang"
-    export LDSHARED="$(brew --prefix llvm)/bin/clang -shared"
+    # HOMEBREW_NO_AUTO_UPDATE=1 brew install llvm libomp
 else
     # Assume Ubuntu: install a recent version of clang and libomp
     echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
@@ -29,7 +28,9 @@ if [[ "$PACKAGER" == "conda" ]]; then
     if [[ "$NO_NUMPY" != "true" ]]; then
          TO_INSTALL="$TO_INSTALL numpy"
     fi
-
+    if [[ "$UNAMESTR" == "Darwin" ]]; then
+         TO_INSTALL="$TO_INSTALL llvm-openmp clang"
+    fi
 	make_conda $TO_INSTALL
 
 elif [[ "$PACKAGER" == "ubuntu" ]]; then

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -26,6 +26,8 @@ elif [[ "$CC_OUTER_LOOP" == "clang-8" || "$CC_INNER_LOOP" == "clang-8" ]]; then
     sudo apt install clang-8 libomp-8-dev
 fi
 
+sudo apt install gdb
+
 make_conda() {
     TO_INSTALL="$@"
     conda create -n $VIRTUALENV -q --yes $TO_INSTALL

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -5,9 +5,8 @@ set -e
 UNAMESTR=`uname`
 
 if [[ "$UNAMESTR" == "Darwin" ]]; then
-    echo "macOS detected"
     # Install a compiler with a working openmp
-    # HOMEBREW_NO_AUTO_UPDATE=1 brew install llvm libomp
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install llvm libomp
 else
     # Assume Ubuntu: install a recent version of clang and libomp
     echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
@@ -27,9 +26,6 @@ if [[ "$PACKAGER" == "conda" ]]; then
     TO_INSTALL="python=$VERSION_PYTHON pip pytest pytest-cov cython"
     if [[ "$NO_NUMPY" != "true" ]]; then
          TO_INSTALL="$TO_INSTALL numpy"
-    fi
-    if [[ "$UNAMESTR" == "Darwin" ]]; then
-         TO_INSTALL="$TO_INSTALL llvm-openmp clang"
     fi
 	make_conda $TO_INSTALL
 

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -17,13 +17,13 @@ if [[ "$UNAMESTR" == "Darwin" ]]; then
     export LDFLAGS="$LDFLAGS -L/usr/local/opt/libomp/lib -lomp"
     export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib
 else
-    # Assume Ubuntu: install a recent version of clang and libomp to avoid a
-    # deadlock when used in conjunction with Intel libiomp.
-    echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
-    echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-    sudo apt update
-    sudo apt install clang-8 libomp-8-dev
+    # Assume Ubuntu: install a recent version of clang and libomp
+    # echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
+    # echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
+    # wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+    # sudo apt update
+    # sudo apt install clang-8 libomp-8-dev
+    echo "Using preinstalled clang-6.0 / libomp-dev"
 fi
 
 make_conda() {

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -7,15 +7,6 @@ UNAMESTR=`uname`
 if [[ "$UNAMESTR" == "Darwin" ]]; then
     # Install gcc on macOS to get a compiler with a working openmp
     HOMEBREW_NO_AUTO_UPDATE=1 brew install gcc@8
-
-    # enable OpenMP support for Apple-clang
-    export CC=/usr/bin/clang
-    export CXX=/usr/bin/clang++
-    export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"
-    export CFLAGS="$CFLAGS -I/usr/local/opt/libomp/include"
-    export CXXFLAGS="$CXXFLAGS -I/usr/local/opt/libomp/include"
-    export LDFLAGS="$LDFLAGS -L/usr/local/opt/libomp/lib -lomp"
-    export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib
 else
     # Assume Ubuntu: install a recent version of clang and libomp
     echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -30,6 +30,7 @@ sudo apt install gdb
 
 make_conda() {
     TO_INSTALL="$@"
+    source /usr/share/miniconda/etc/profile.d/conda.sh
     conda create -n $VIRTUALENV -q --yes $TO_INSTALL
     conda activate $VIRTUALENV
 }

--- a/continuous_integration/posix.yml
+++ b/continuous_integration/posix.yml
@@ -14,7 +14,7 @@ jobs:
   steps:
     - bash: echo "##vso[task.prependpath]$CONDA/bin"
       displayName: Add conda to PATH
-      condition: eq(variables['PACKAGER'], 'conda')
+      condition: eq(variables['PACKAGER'], 'conda') or eq(variables['PACKAGER'], 'pip')
     - script: |
         continuous_integration/install.sh
       displayName: 'Install'

--- a/continuous_integration/posix.yml
+++ b/continuous_integration/posix.yml
@@ -14,7 +14,7 @@ jobs:
   steps:
     - bash: echo "##vso[task.prependpath]$CONDA/bin"
       displayName: Add conda to PATH
-      condition: eq(variables['PACKAGER'], 'conda') or eq(variables['PACKAGER'], 'pip')
+      condition: or(eq(variables['PACKAGER'], 'conda'), eq(variables['PACKAGER'], 'pip'))
     - script: |
         continuous_integration/install.sh
       displayName: 'Install'

--- a/continuous_integration/test_script.cmd
+++ b/continuous_integration/test_script.cmd
@@ -1,3 +1,3 @@
 call activate %VIRTUALENV%
 
-pytest -vl --junitxml=%JUNITXML% --cov=threadpoolctl
+pytest -vlrxXs --junitxml=%JUNITXML% --cov=threadpoolctl

--- a/continuous_integration/test_script.cmd
+++ b/continuous_integration/test_script.cmd
@@ -1,3 +1,3 @@
 call activate %VIRTUALENV%
 
-pytest -vlx --junitxml=%JUNITXML% --cov=threadpoolctl
+pytest -vl --junitxml=%JUNITXML% --cov=threadpoolctl

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -14,4 +14,4 @@ fi
 set -x
 PYTHONPATH="." python continuous_integration/display_versions.py
 
-pytest -vl --junitxml=$JUNITXML --cov=threadpoolctl
+pytest -vlrxXs --junitxml=$JUNITXML --cov=threadpoolctl

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -8,6 +8,7 @@ elif [[ "$PACKAGER" == "ubuntu" ]]; then
     source $VIRTUALENV/bin/activate
 fi
 
+python -c "import numpy; from tests._openmp_test_helper_outer import *; from threadpoolctl import threadpool_info; from pprint import pprint; pprint(threadpool_info())"
 set -x
 pytest -vlx --junitxml=$JUNITXML --cov=threadpoolctl
 set +x

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -14,4 +14,4 @@ fi
 set -x
 PYTHONPATH="." python continuous_integration/display_versions.py
 
-pytest -vl --junitxml=$JUNITXML --cov=threadpoolctl
+pytest -vsxl --junitxml=$JUNITXML --cov=threadpoolctl

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -14,4 +14,4 @@ fi
 set -x
 PYTHONPATH="." python continuous_integration/display_versions.py
 
-pytest -vsxl --junitxml=$JUNITXML --cov=threadpoolctl
+pytest -vl --junitxml=$JUNITXML --cov=threadpoolctl

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -9,5 +9,9 @@ elif [[ "$PACKAGER" == "ubuntu" ]]; then
 fi
 
 set -x
-pytest -vl --junitxml=$JUNITXML --cov=threadpoolctl
+pytest -vl --junitxml=$JUNITXML --cov=threadpoolctl &
+sleep 5
+sudo gdb -p $! -ex "set confirm off" -ex "thread apply all bt" -ex q
+fg
+
 set +x

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -13,10 +13,3 @@ fi
 
 set -x
 PYTHONPATH="." python continuous_integration/display_versions.py
-
-pytest -vl --junitxml=$JUNITXML --cov=threadpoolctl &
-sleep 5
-sudo gdb -p $! -ex "set confirm off" -ex "thread apply all bt" -ex q
-fg
-
-set +x

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -8,7 +8,6 @@ elif [[ "$PACKAGER" == "ubuntu" ]]; then
     source $VIRTUALENV/bin/activate
 fi
 
-python -c "import numpy; from tests._openmp_test_helper_outer import *; from threadpoolctl import threadpool_info; from pprint import pprint; pprint(threadpool_info())"
 set -x
 pytest -vlx --junitxml=$JUNITXML --cov=threadpoolctl
 set +x

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -4,6 +4,9 @@ set -e
 
 if [[ "$PACKAGER" == "conda" ]]; then
     source activate $VIRTUALENV
+elif [[ "$PACKAGER" == "pip" ]]; then
+    # we actually use conda to install the base environment:
+    source activate $VIRTUALENV
 elif [[ "$PACKAGER" == "ubuntu" ]]; then
     source $VIRTUALENV/bin/activate
 fi

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -9,5 +9,5 @@ elif [[ "$PACKAGER" == "ubuntu" ]]; then
 fi
 
 set -x
-pytest -vlx --junitxml=$JUNITXML --cov=threadpoolctl
+pytest -vl --junitxml=$JUNITXML --cov=threadpoolctl
 set +x

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -9,6 +9,8 @@ elif [[ "$PACKAGER" == "ubuntu" ]]; then
 fi
 
 set -x
+PYTHONPATH="." python continuous_integration/display_versions.py
+
 pytest -vl --junitxml=$JUNITXML --cov=threadpoolctl &
 sleep 5
 sudo gdb -p $! -ex "set confirm off" -ex "thread apply all bt" -ex q

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -13,3 +13,5 @@ fi
 
 set -x
 PYTHONPATH="." python continuous_integration/display_versions.py
+
+pytest -vl --junitxml=$JUNITXML --cov=threadpoolctl

--- a/tests/_openmp_test_helper/__init__.py
+++ b/tests/_openmp_test_helper/__init__.py
@@ -1,8 +1,12 @@
 from .openmp_helpers_inner import check_openmp_num_threads
 from .openmp_helpers_inner import get_compiler as get_inner_compiler
 from .openmp_helpers_outer import check_nested_openmp_loops
+from .openmp_helpers_outer import check_nested_prange_blas
 from .openmp_helpers_outer import get_compiler as get_outer_compiler
 
 
-__all__ = ["check_openmp_num_threads", "check_nested_openmp_loops",
-           "get_inner_copiler", "get_outer_compiler"]
+__all__ = ["check_openmp_num_threads",
+           "check_nested_openmp_loops",
+           "check_nested_prange_blas",
+           "get_inner_compiler",
+           "get_outer_compiler"]

--- a/tests/_openmp_test_helper/__init__.py
+++ b/tests/_openmp_test_helper/__init__.py
@@ -1,8 +1,8 @@
 from .openmp_helpers_inner import check_openmp_num_threads
 from .openmp_helpers_inner import get_compiler as get_inner_compiler
 from .openmp_helpers_outer import check_nested_openmp_loops
-from .openmp_helpers_outer import check_nested_prange_blas
 from .openmp_helpers_outer import get_compiler as get_outer_compiler
+from .nested_prange_blas import check_nested_prange_blas
 
 
 __all__ = ["check_openmp_num_threads",

--- a/tests/_openmp_test_helper/__init__.py
+++ b/tests/_openmp_test_helper/__init__.py
@@ -1,4 +1,8 @@
-from .openmp_helpers import check_openmp_num_threads
+from .openmp_helpers_inner import check_openmp_num_threads
+from .openmp_helpers_inner import get_compiler as get_inner_compiler
+from .openmp_helpers_outer import check_nested_openmp_loops
+from .openmp_helpers_outer import get_compiler as get_outer_compiler
 
 
-__all__ = ["check_openmp_num_threads"]
+__all__ = ["check_openmp_num_threads", "check_nested_openmp_loops",
+           "get_inner_copiler", "get_outer_compiler"]

--- a/tests/_openmp_test_helper/build_utils.py
+++ b/tests/_openmp_test_helper/build_utils.py
@@ -13,3 +13,11 @@ def set_cc_variables(var_name="CC"):
             os.environ["LDSHARED"] = cc_var + " -shared"
 
     return cc_var
+
+
+def get_openmp_flag():
+    if sys.platform == "win32":
+        return ["/openmp"]
+    elif sys.platform == "darwin" and 'openmp' in os.getenv('CPPFLAGS', ''):
+        return []
+    return ["-fopenmp"]

--- a/tests/_openmp_test_helper/build_utils.py
+++ b/tests/_openmp_test_helper/build_utils.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+
+def set_cc_variables(var_name="CC"):
+    cc_var = os.environ.get(var_name)
+    if cc_var is not None:
+        os.environ["CC"] = cc_var
+        if sys.platform == "darwin":
+            os.environ["LDSHARED"] = (
+                cc_var + " -bundle -undefined dynamic_lookup")
+        else:
+            os.environ["LDSHARED"] = cc_var + " -shared"
+
+    return cc_var

--- a/tests/_openmp_test_helper/nested_prange_blas.pyx
+++ b/tests/_openmp_test_helper/nested_prange_blas.pyx
@@ -1,0 +1,42 @@
+cimport openmp
+from cython.parallel import prange
+
+import numpy as np
+from scipy.linalg.cython_blas cimport dgemm
+
+from threadpoolctl import threadpool_info
+
+
+def check_nested_prange_blas(double[:, ::1] A, double[:, ::1] B, int nthreads):
+    """Run multithreaded BLAS calls within OpenMP parallel loop"""
+    cdef:
+        int m = A.shape[0]
+        int n = B.shape[0]
+        int k = A.shape[1]
+
+        double[:, ::1] C = np.empty((m, n))
+        int n_chunks = 100
+        int chunk_size = A.shape[0] // n_chunks
+
+        char* trans = 't'
+        char* no_trans = 'n'
+        double alpha = 1.0
+        double beta = 0.0
+
+        int i
+        int prange_num_threads
+    
+    threadpool_infos = None
+
+    for i in prange(n_chunks, num_threads=nthreads, nogil=True):
+        dgemm(trans, no_trans, &n, &chunk_size, &k,
+              &alpha, &B[0, 0], &k, &A[i * chunk_size, 0], &k,
+              &beta, &C[i * chunk_size, 0], &n)
+    
+        prange_num_threads = openmp.omp_get_num_threads()
+
+        if i == 0:
+            with gil:
+                threadpool_infos = threadpool_info()
+
+    return np.asarray(C), prange_num_threads, threadpool_infos

--- a/tests/_openmp_test_helper/nested_prange_blas.pyx
+++ b/tests/_openmp_test_helper/nested_prange_blas.pyx
@@ -35,8 +35,8 @@ def check_nested_prange_blas(double[:, ::1] A, double[:, ::1] B, int nthreads):
 
         prange_num_threads = openmp.omp_get_num_threads()
 
-        # if i == 0:
-        #     with gil:
-        #         threadpool_infos = threadpool_info()
+        if i == 0:
+            with gil:
+                threadpool_infos = threadpool_info()
 
     return np.asarray(C), prange_num_threads, [] # threadpool_infos

--- a/tests/_openmp_test_helper/nested_prange_blas.pyx
+++ b/tests/_openmp_test_helper/nested_prange_blas.pyx
@@ -39,4 +39,4 @@ def check_nested_prange_blas(double[:, ::1] A, double[:, ::1] B, int nthreads):
             with gil:
                 threadpool_infos = threadpool_info()
 
-    return np.asarray(C), prange_num_threads, [] # threadpool_infos
+    return np.asarray(C), prange_num_threads, threadpool_infos

--- a/tests/_openmp_test_helper/nested_prange_blas.pyx
+++ b/tests/_openmp_test_helper/nested_prange_blas.pyx
@@ -25,18 +25,18 @@ def check_nested_prange_blas(double[:, ::1] A, double[:, ::1] B, int nthreads):
 
         int i
         int prange_num_threads
-    
+
     threadpool_infos = None
 
     for i in prange(n_chunks, num_threads=nthreads, nogil=True):
         dgemm(trans, no_trans, &n, &chunk_size, &k,
               &alpha, &B[0, 0], &k, &A[i * chunk_size, 0], &k,
               &beta, &C[i * chunk_size, 0], &n)
-    
+
         prange_num_threads = openmp.omp_get_num_threads()
 
-        if i == 0:
-            with gil:
-                threadpool_infos = threadpool_info()
+        # if i == 0:
+        #     with gil:
+        #         threadpool_infos = threadpool_info()
 
-    return np.asarray(C), prange_num_threads, threadpool_infos
+    return np.asarray(C), prange_num_threads, [] # threadpool_infos

--- a/tests/_openmp_test_helper/openmp_helpers.pxd
+++ b/tests/_openmp_test_helper/openmp_helpers.pxd
@@ -1,1 +1,0 @@
-cdef int inner_openmp_loop(int n) nogil

--- a/tests/_openmp_test_helper/openmp_helpers_inner.pxd
+++ b/tests/_openmp_test_helper/openmp_helpers_inner.pxd
@@ -1,0 +1,1 @@
+cdef int inner_openmp_loop(int) nogil

--- a/tests/_openmp_test_helper/openmp_helpers_inner.pxd
+++ b/tests/_openmp_test_helper/openmp_helpers_inner.pxd
@@ -1,1 +1,1 @@
-cdef int inner_openmp_loop(int) nogil
+cdef int inner_openmp_loop(int, int) nogil

--- a/tests/_openmp_test_helper/openmp_helpers_inner.pxd
+++ b/tests/_openmp_test_helper/openmp_helpers_inner.pxd
@@ -1,1 +1,1 @@
-cdef int inner_openmp_loop(int, int) nogil
+cdef int inner_openmp_loop(int) nogil

--- a/tests/_openmp_test_helper/openmp_helpers_inner.pyx
+++ b/tests/_openmp_test_helper/openmp_helpers_inner.pyx
@@ -1,7 +1,5 @@
 cimport openmp
 from cython.parallel import prange
-from pprint import pprint
-from threadpoolctl import threadpool_info
 
 
 def check_openmp_num_threads(int n):
@@ -13,20 +11,11 @@ def check_openmp_num_threads(int n):
     cdef int num_threads = -1
 
     with nogil:
-        num_threads = inner_openmp_loop(n, 0)
+        num_threads = inner_openmp_loop(n)
     return num_threads
 
 
-def print_omp_debug_info(outerloop_idx, num_threads):
-    msg = "[%d] " % outerloop_idx
-    msg += ", ".join(m['prefix'] + ": %d" % m['num_threads']
-                    for m in threadpool_info()
-                    if m["user_api"] == "openmp")
-    msg += ", inner loop omp_get_num_threads: %d" % num_threads
-    print(msg, flush=True)
-
-
-cdef int inner_openmp_loop(int n, int outerloop_idx) nogil:
+cdef int inner_openmp_loop(int n) nogil:
     """Run a short parallel section with OpenMP
 
     Return the number of threads that where effectively used by the
@@ -36,13 +25,11 @@ cdef int inner_openmp_loop(int n, int outerloop_idx) nogil:
     by an outer OpenMP / prange loop written in Cython in anoter file.
     """
     cdef long n_sum = 0
-    cdef int i, num_threads = 0
+    cdef int i, num_threads
 
     for i in prange(n):
         num_threads = openmp.omp_get_num_threads()
         n_sum += i
-        with gil:
-            print_omp_debug_info(outerloop_idx, num_threads)
 
     if n_sum != (n - 1) * n / 2:
         # error

--- a/tests/_openmp_test_helper/openmp_helpers_inner.pyx
+++ b/tests/_openmp_test_helper/openmp_helpers_inner.pyx
@@ -28,11 +28,11 @@ cdef int inner_openmp_loop(int n) nogil:
 
     for i in prange(n):
         num_threads = openmp.omp_get_num_threads()
-        # n_sum += i
+        n_sum += i
 
-    # if n_sum != (n - 1) * n / 2:
-    #     # error
-    #     return -1
+    if n_sum != (n - 1) * n / 2:
+        # error
+        return -1
 
     return num_threads
 

--- a/tests/_openmp_test_helper/openmp_helpers_inner.pyx
+++ b/tests/_openmp_test_helper/openmp_helpers_inner.pyx
@@ -8,7 +8,8 @@ def check_openmp_num_threads(int n):
     Return the number of threads that where effectively used by the
     OpenMP runtime.
     """
-    cdef int num_threads
+    cdef int num_threads = -1
+
     with nogil:
         num_threads = inner_openmp_loop(n)
     return num_threads

--- a/tests/_openmp_test_helper/openmp_helpers_inner.pyx
+++ b/tests/_openmp_test_helper/openmp_helpers_inner.pyx
@@ -28,15 +28,14 @@ cdef int inner_openmp_loop(int n) nogil:
 
     for i in prange(n):
         num_threads = openmp.omp_get_num_threads()
-        n_sum += i
+        # n_sum += i
 
-    if n_sum != (n - 1) * n / 2:
-        # error
-        return -1
-    
+    # if n_sum != (n - 1) * n / 2:
+    #     # error
+    #     return -1
+
     return num_threads
 
 
 def get_compiler():
     return CC_INNER_LOOP
-

--- a/tests/_openmp_test_helper/openmp_helpers_inner.pyx
+++ b/tests/_openmp_test_helper/openmp_helpers_inner.pyx
@@ -1,7 +1,5 @@
-import cython
 cimport openmp
 from cython.parallel import prange
-from libc.stdlib cimport malloc, free
 
 
 def check_openmp_num_threads(int n):
@@ -37,3 +35,8 @@ cdef int inner_openmp_loop(int n) nogil:
         return -1
     
     return num_threads
+
+
+def get_compiler():
+    return CC_INNER_LOOP
+

--- a/tests/_openmp_test_helper/openmp_helpers_outer.pyx
+++ b/tests/_openmp_test_helper/openmp_helpers_outer.pyx
@@ -2,6 +2,11 @@ cimport openmp
 from cython.parallel import prange
 from openmp_helpers_inner cimport inner_openmp_loop
 
+import numpy as np
+from scipy.linalg.cython_blas cimport dgemm
+
+from threadpoolctl import threadpool_info
+
 
 def check_nested_openmp_loops(int n):
     """Run a short parallel section with OpenMP with nested calls
@@ -16,6 +21,44 @@ def check_nested_openmp_loops(int n):
         outer_num_threads = openmp.omp_get_num_threads()
         
     return outer_num_threads, inner_num_threads
+
+
+def check_nested_prange_blas(double[:, ::1] A, double[:, ::1] B, int nthreads):
+    """Run multithreaded BLAS calls within OpenMP parallel loop"""
+    cdef:
+        int m = A.shape[0]
+        int n = B.shape[0]
+        int k = A.shape[1]
+
+        double[:, ::1] C = np.empty((m, n))
+        int n_chunks = 100
+        int chunk_size = A.shape[0] // n_chunks
+
+        char* trans = 't'
+        char* no_trans = 'n'
+        double alpha = 1.0
+        double beta = 0.0
+
+        int i
+        int prange_num_threads
+    
+    blas_num_threads = []
+
+    for i in prange(n_chunks, num_threads=nthreads, nogil=True):
+        dgemm(trans, no_trans, &n, &chunk_size, &k,
+              &alpha, &B[0, 0], &k, &A[i * chunk_size, 0], &k,
+              &beta, &C[i * chunk_size, 0], &n)
+    
+        prange_num_threads = openmp.omp_get_num_threads()
+
+        if i == 0:
+            with gil:
+                infos = threadpool_info()
+                for lib in infos:
+                    if lib['user_api'] == 'blas':
+                        blas_num_threads.append(lib['num_threads'])
+
+    return np.asarray(C), prange_num_threads, blas_num_threads
 
 
 def get_compiler():

--- a/tests/_openmp_test_helper/openmp_helpers_outer.pyx
+++ b/tests/_openmp_test_helper/openmp_helpers_outer.pyx
@@ -1,8 +1,6 @@
-import cython
 cimport openmp
 from cython.parallel import prange
-from libc.stdlib cimport malloc, free
-from tests._openmp_test_helper.openmp_helpers cimport inner_openmp_loop
+from openmp_helpers_inner cimport inner_openmp_loop
 
 
 def check_nested_openmp_loops(int n):
@@ -19,3 +17,6 @@ def check_nested_openmp_loops(int n):
         
     return outer_num_threads, inner_num_threads
 
+
+def get_compiler():
+    return CC_OUTER_LOOP

--- a/tests/_openmp_test_helper/openmp_helpers_outer.pyx
+++ b/tests/_openmp_test_helper/openmp_helpers_outer.pyx
@@ -3,15 +3,17 @@ from cython.parallel import prange
 from openmp_helpers_inner cimport inner_openmp_loop
 
 
-def check_nested_openmp_loops(int n):
+def check_nested_openmp_loops(int n, nthreads=None):
     """Run a short parallel section with OpenMP with nested calls
 
     The inner OpenMP loop has not necessarily been built/linked with the
     same runtime OpenMP runtime.
     """
-    cdef int outer_num_threads, inner_num_threads, i
+    cdef:
+        int outer_num_threads, inner_num_threads, i
+        int num_threads = nthreads or openmp.omp_get_max_threads()
 
-    for i in prange(n, nogil=True):
+    for i in prange(n, num_threads=num_threads, nogil=True):
         inner_num_threads = inner_openmp_loop(n)
         outer_num_threads = openmp.omp_get_num_threads()
         

--- a/tests/_openmp_test_helper/openmp_helpers_outer.pyx
+++ b/tests/_openmp_test_helper/openmp_helpers_outer.pyx
@@ -10,8 +10,10 @@ def check_nested_openmp_loops(int n, nthreads=None):
     same runtime OpenMP runtime.
     """
     cdef:
-        int outer_num_threads, inner_num_threads, i
+        int outer_num_threads = -1
+        int inner_num_threads = -1
         int num_threads = nthreads or openmp.omp_get_max_threads()
+        int i
 
     for i in prange(n, num_threads=num_threads, nogil=True):
         inner_num_threads = inner_openmp_loop(n)

--- a/tests/_openmp_test_helper/openmp_helpers_outer.pyx
+++ b/tests/_openmp_test_helper/openmp_helpers_outer.pyx
@@ -16,7 +16,7 @@ def check_nested_openmp_loops(int n, nthreads=None):
         int i
 
     for i in prange(n, num_threads=num_threads, nogil=True):
-        inner_num_threads = inner_openmp_loop(n)
+        inner_num_threads = inner_openmp_loop(n, i)
         outer_num_threads = openmp.omp_get_num_threads()
         
     return outer_num_threads, inner_num_threads

--- a/tests/_openmp_test_helper/openmp_helpers_outer.pyx
+++ b/tests/_openmp_test_helper/openmp_helpers_outer.pyx
@@ -16,7 +16,7 @@ def check_nested_openmp_loops(int n, nthreads=None):
         int i
 
     for i in prange(n, num_threads=num_threads, nogil=True):
-        inner_num_threads = inner_openmp_loop(n, i)
+        inner_num_threads = inner_openmp_loop(n)
         outer_num_threads = openmp.omp_get_num_threads()
         
     return outer_num_threads, inner_num_threads

--- a/tests/_openmp_test_helper/openmp_helpers_outer.pyx
+++ b/tests/_openmp_test_helper/openmp_helpers_outer.pyx
@@ -2,11 +2,6 @@ cimport openmp
 from cython.parallel import prange
 from openmp_helpers_inner cimport inner_openmp_loop
 
-import numpy as np
-from scipy.linalg.cython_blas cimport dgemm
-
-from threadpoolctl import threadpool_info
-
 
 def check_nested_openmp_loops(int n):
     """Run a short parallel section with OpenMP with nested calls
@@ -21,44 +16,6 @@ def check_nested_openmp_loops(int n):
         outer_num_threads = openmp.omp_get_num_threads()
         
     return outer_num_threads, inner_num_threads
-
-
-def check_nested_prange_blas(double[:, ::1] A, double[:, ::1] B, int nthreads):
-    """Run multithreaded BLAS calls within OpenMP parallel loop"""
-    cdef:
-        int m = A.shape[0]
-        int n = B.shape[0]
-        int k = A.shape[1]
-
-        double[:, ::1] C = np.empty((m, n))
-        int n_chunks = 100
-        int chunk_size = A.shape[0] // n_chunks
-
-        char* trans = 't'
-        char* no_trans = 'n'
-        double alpha = 1.0
-        double beta = 0.0
-
-        int i
-        int prange_num_threads
-    
-    blas_num_threads = []
-
-    for i in prange(n_chunks, num_threads=nthreads, nogil=True):
-        dgemm(trans, no_trans, &n, &chunk_size, &k,
-              &alpha, &B[0, 0], &k, &A[i * chunk_size, 0], &k,
-              &beta, &C[i * chunk_size, 0], &n)
-    
-        prange_num_threads = openmp.omp_get_num_threads()
-
-        if i == 0:
-            with gil:
-                infos = threadpool_info()
-                for lib in infos:
-                    if lib['user_api'] == 'blas':
-                        blas_num_threads.append(lib['num_threads'])
-
-    return np.asarray(C), prange_num_threads, blas_num_threads
 
 
 def get_compiler():

--- a/tests/_openmp_test_helper/setup_inner.py
+++ b/tests/_openmp_test_helper/setup_inner.py
@@ -4,6 +4,7 @@ from distutils.core import setup
 from Cython.Build import cythonize
 from distutils.extension import Extension
 
+
 original_environ = os.environ.copy()
 try:
     # Make it possible to compile the 2 OpenMP enabled Cython extensions

--- a/tests/_openmp_test_helper/setup_inner.py
+++ b/tests/_openmp_test_helper/setup_inner.py
@@ -35,7 +35,10 @@ try:
         ext_modules=cythonize(
             ext_modules,
             language_level=3,
-            compile_time_env={"CC_INNER_LOOP": inner_loop_cc_var or "unknown"}),
+            compiler_directives={'language_level': 3,
+                                 'boundscheck': False,
+                                 'wraparound': False},
+            compile_time_env={"CC_INNER_LOOP": inner_loop_cc_var or "unknown"})
     )
 
 finally:

--- a/tests/_openmp_test_helper/setup_inner.py
+++ b/tests/_openmp_test_helper/setup_inner.py
@@ -4,10 +4,8 @@ from distutils.core import setup
 from Cython.Build import cythonize
 from distutils.extension import Extension
 
-
 original_environ = os.environ.copy()
 try:
-    sys.path.append("..")
     # The default compiler on macOS is named gcc but is an alias to a clang
     # compiler that does not have an openmp runtime installed by default.
     if sys.platform == "darwin":
@@ -15,34 +13,34 @@ try:
 
     # Make it possible to compile the 2 OpenMP enabled Cython extensions
     # with different compilers and therefore different OpenMP runtimes.
-    outer_loop_cc_var = os.environ.get("CC_OUTER_LOOP")
-    if outer_loop_cc_var is not None:
-        os.environ["CC"] = outer_loop_cc_var
-        os.environ["LDSHARED"] = outer_loop_cc_var + " -shared"
+    inner_loop_cc_var = os.environ.get("CC_INNER_LOOP")
+    if inner_loop_cc_var is not None:
+        os.environ["CC"] = inner_loop_cc_var
+        os.environ["LDSHARED"] = inner_loop_cc_var + " -shared"
 
     if sys.platform == "win32":
         extra_compile_args = ["/openmp"]
         extra_link_args = None
     else:
         extra_compile_args = ["-fopenmp"]
-        extra_link_args = ['-fopenmp']
+        extra_link_args = ["-fopenmp"]
 
     ext_modules = [
         Extension(
-            "openmp_helpers_outer",
-            ["openmp_helpers_outer.pyx"],
+            "openmp_helpers_inner",
+            ["openmp_helpers_inner.pyx"],
             extra_compile_args=extra_compile_args,
             extra_link_args=extra_link_args
             )
     ]
 
     setup(
-        name='_openmp_test_helper_outer',
+        name='_openmp_test_helper_inner',
         ext_modules=cythonize(
             ext_modules,
-            language_level=3),
+            language_level=3,
+            compile_time_env={"CC_INNER_LOOP": inner_loop_cc_var or "unknown"}),
     )
 
 finally:
     os.environ.update(original_environ)
-    sys.path.remove('..')

--- a/tests/_openmp_test_helper/setup_inner.py
+++ b/tests/_openmp_test_helper/setup_inner.py
@@ -16,7 +16,7 @@ try:
 
     if sys.platform == "win32":
         extra_compile_args = ["/openmp"]
-        extra_link_args = None
+        extra_link_args = []
     else:
         extra_compile_args = ["-fopenmp"]
         extra_link_args = ["-fopenmp"]

--- a/tests/_openmp_test_helper/setup_inner.py
+++ b/tests/_openmp_test_helper/setup_inner.py
@@ -4,19 +4,14 @@ from distutils.core import setup
 from Cython.Build import cythonize
 from distutils.extension import Extension
 
+from build_utils import set_cc_variables
+
 
 original_environ = os.environ.copy()
 try:
     # Make it possible to compile the 2 OpenMP enabled Cython extensions
     # with different compilers and therefore different OpenMP runtimes.
-    inner_loop_cc_var = os.environ.get("CC_INNER_LOOP")
-    if inner_loop_cc_var is not None:
-        os.environ["CC"] = inner_loop_cc_var
-        if sys.platform == "darwin":
-            os.environ["LDSHARED"] = (
-                inner_loop_cc_var + " -bundle -undefined dynamic_lookup")
-        else:
-            os.environ["LDSHARED"] = inner_loop_cc_var + " -shared"
+    inner_loop_cc_var = set_cc_variables("CC_INNER_LOOP")
 
     if sys.platform == "win32":
         openmp_flag = ["/openmp"]

--- a/tests/_openmp_test_helper/setup_inner.py
+++ b/tests/_openmp_test_helper/setup_inner.py
@@ -12,21 +12,25 @@ try:
     inner_loop_cc_var = os.environ.get("CC_INNER_LOOP")
     if inner_loop_cc_var is not None:
         os.environ["CC"] = inner_loop_cc_var
-        os.environ["LDSHARED"] = inner_loop_cc_var + " -shared"
+        if sys.platform == "darwin":
+            os.environ["LDSHARED"] = (
+                inner_loop_cc_var + " -bundle -undefined dynamic_lookup")
+        else:
+            os.environ["LDSHARED"] = inner_loop_cc_var + " -shared"
 
     if sys.platform == "win32":
-        extra_compile_args = ["/openmp"]
-        extra_link_args = []
+        openmp_flag = ["/openmp"]
+    elif sys.platform == "darwin" and 'openmp' in os.getenv('CPPFLAGS', ''):
+        openmp_flag = []
     else:
-        extra_compile_args = ["-fopenmp"]
-        extra_link_args = ["-fopenmp"]
+        openmp_flag = ["-fopenmp"]
 
     ext_modules = [
         Extension(
             "openmp_helpers_inner",
             ["openmp_helpers_inner.pyx"],
-            extra_compile_args=extra_compile_args,
-            extra_link_args=extra_link_args
+            extra_compile_args=openmp_flag,
+            extra_link_args=openmp_flag
             )
     ]
 

--- a/tests/_openmp_test_helper/setup_inner.py
+++ b/tests/_openmp_test_helper/setup_inner.py
@@ -6,11 +6,6 @@ from distutils.extension import Extension
 
 original_environ = os.environ.copy()
 try:
-    # The default compiler on macOS is named gcc but is an alias to a clang
-    # compiler that does not have an openmp runtime installed by default.
-    if sys.platform == "darwin":
-        os.environ["CC"] = "gcc-4.9"
-
     # Make it possible to compile the 2 OpenMP enabled Cython extensions
     # with different compilers and therefore different OpenMP runtimes.
     inner_loop_cc_var = os.environ.get("CC_INNER_LOOP")

--- a/tests/_openmp_test_helper/setup_inner.py
+++ b/tests/_openmp_test_helper/setup_inner.py
@@ -1,10 +1,10 @@
 import os
-import sys
 from distutils.core import setup
 from Cython.Build import cythonize
 from distutils.extension import Extension
 
 from build_utils import set_cc_variables
+from build_utils import get_openmp_flag
 
 
 original_environ = os.environ.copy()
@@ -12,13 +12,7 @@ try:
     # Make it possible to compile the 2 OpenMP enabled Cython extensions
     # with different compilers and therefore different OpenMP runtimes.
     inner_loop_cc_var = set_cc_variables("CC_INNER_LOOP")
-
-    if sys.platform == "win32":
-        openmp_flag = ["/openmp"]
-    elif sys.platform == "darwin" and 'openmp' in os.getenv('CPPFLAGS', ''):
-        openmp_flag = []
-    else:
-        openmp_flag = ["-fopenmp"]
+    openmp_flag = get_openmp_flag()
 
     ext_modules = [
         Extension(
@@ -33,7 +27,6 @@ try:
         name='_openmp_test_helper_inner',
         ext_modules=cythonize(
             ext_modules,
-            language_level=3,
             compiler_directives={'language_level': 3,
                                  'boundscheck': False,
                                  'wraparound': False},

--- a/tests/_openmp_test_helper/setup_nested_prange_blas.py
+++ b/tests/_openmp_test_helper/setup_nested_prange_blas.py
@@ -1,36 +1,34 @@
 import os
-import sys
 from distutils.core import setup
 from Cython.Build import cythonize
 from distutils.extension import Extension
 
 from build_utils import set_cc_variables
+from build_utils import get_openmp_flag
 
 
-set_cc_variables("CC_OUTER_LOOP")
+original_environ = os.environ.copy()
+try:
+    set_cc_variables("CC_OUTER_LOOP")
+    openmp_flag = get_openmp_flag()
 
-if sys.platform == "win32":
-    openmp_flag = ["/openmp"]
-elif sys.platform == "darwin" and 'openmp' in os.getenv('CPPFLAGS', ''):
-    openmp_flag = []
-else:
-    openmp_flag = ["-fopenmp"]
+    ext_modules = [
+        Extension(
+            "nested_prange_blas",
+            ["nested_prange_blas.pyx"],
+            extra_compile_args=openmp_flag,
+            extra_link_args=openmp_flag
+            )
+    ]
 
-ext_modules = [
-    Extension(
-        "nested_prange_blas",
-        ["nested_prange_blas.pyx"],
-        extra_compile_args=openmp_flag,
-        extra_link_args=openmp_flag
-        )
-]
+    setup(
+        name='_openmp_test_helper_nested_prange_blas',
+        ext_modules=cythonize(
+            ext_modules,
+            compiler_directives={'language_level': 3,
+                                 'boundscheck': False,
+                                 'wraparound': False})
+    )
 
-setup(
-    name='_openmp_test_helper_nested_prange_blas',
-    ext_modules=cythonize(
-        ext_modules,
-        language_level=3,
-        compiler_directives={'language_level': 3,
-                             'boundscheck': False,
-                             'wraparound': False})
-)
+finally:
+    os.environ.update(original_environ)

--- a/tests/_openmp_test_helper/setup_nested_prange_blas.py
+++ b/tests/_openmp_test_helper/setup_nested_prange_blas.py
@@ -4,6 +4,10 @@ from distutils.core import setup
 from Cython.Build import cythonize
 from distutils.extension import Extension
 
+from build_utils import set_cc_variables
+
+
+set_cc_variables("CC_OUTER_LOOP")
 
 if sys.platform == "win32":
     openmp_flag = ["/openmp"]

--- a/tests/_openmp_test_helper/setup_nested_prange_blas.py
+++ b/tests/_openmp_test_helper/setup_nested_prange_blas.py
@@ -1,0 +1,32 @@
+import os
+import sys
+from distutils.core import setup
+from Cython.Build import cythonize
+from distutils.extension import Extension
+
+
+if sys.platform == "win32":
+    openmp_flag = ["/openmp"]
+elif sys.platform == "darwin" and 'openmp' in os.getenv('CPPFLAGS', ''):
+    openmp_flag = []
+else:
+    openmp_flag = ["-fopenmp"]
+
+ext_modules = [
+    Extension(
+        "nested_prange_blas",
+        ["nested_prange_blas.pyx"],
+        extra_compile_args=openmp_flag,
+        extra_link_args=openmp_flag
+        )
+]
+
+setup(
+    name='_openmp_test_helper_nested_prange_blas',
+    ext_modules=cythonize(
+        ext_modules,
+        language_level=3,
+        compiler_directives={'language_level': 3,
+                             'boundscheck': False,
+                             'wraparound': False})
+)

--- a/tests/_openmp_test_helper/setup_outer.py
+++ b/tests/_openmp_test_helper/setup_outer.py
@@ -7,11 +7,6 @@ from distutils.extension import Extension
 
 original_environ = os.environ.copy()
 try:
-    # The default compiler on macOS is named gcc but is an alias to a clang
-    # compiler that does not have an openmp runtime installed by default.
-    if sys.platform == "darwin":
-        os.environ["CC"] = "gcc-4.9"
-
     # Make it possible to compile the 2 OpenMP enabled Cython extensions
     # with different compilers and therefore different OpenMP runtimes.
     outer_loop_cc_var = os.environ.get("CC_OUTER_LOOP")

--- a/tests/_openmp_test_helper/setup_outer.py
+++ b/tests/_openmp_test_helper/setup_outer.py
@@ -1,10 +1,10 @@
 import os
-import sys
 from distutils.core import setup
 from Cython.Build import cythonize
 from distutils.extension import Extension
 
 from build_utils import set_cc_variables
+from build_utils import get_openmp_flag
 
 
 original_environ = os.environ.copy()
@@ -12,13 +12,7 @@ try:
     # Make it possible to compile the 2 OpenMP enabled Cython extensions
     # with different compilers and therefore different OpenMP runtimes.
     outer_loop_cc_var = set_cc_variables("CC_OUTER_LOOP")
-
-    if sys.platform == "win32":
-        openmp_flag = ["/openmp"]
-    elif sys.platform == "darwin" and 'openmp' in os.getenv('CPPFLAGS', ''):
-        openmp_flag = []
-    else:
-        openmp_flag = ["-fopenmp"]
+    openmp_flag = get_openmp_flag()
 
     ext_modules = [
         Extension(

--- a/tests/_openmp_test_helper/setup_outer.py
+++ b/tests/_openmp_test_helper/setup_outer.py
@@ -4,6 +4,7 @@ from distutils.core import setup
 from Cython.Build import cythonize
 from distutils.extension import Extension
 
+
 original_environ = os.environ.copy()
 try:
     # The default compiler on macOS is named gcc but is an alias to a clang
@@ -13,32 +14,33 @@ try:
 
     # Make it possible to compile the 2 OpenMP enabled Cython extensions
     # with different compilers and therefore different OpenMP runtimes.
-    inner_loop_cc_var = os.environ.get("CC_INNER_LOOP")
-    if inner_loop_cc_var is not None:
-        os.environ["CC"] = inner_loop_cc_var
-        os.environ["LDSHARED"] = inner_loop_cc_var + " -shared"
+    outer_loop_cc_var = os.environ.get("CC_OUTER_LOOP")
+    if outer_loop_cc_var is not None:
+        os.environ["CC"] = outer_loop_cc_var
+        os.environ["LDSHARED"] = outer_loop_cc_var + " -shared"
 
     if sys.platform == "win32":
         extra_compile_args = ["/openmp"]
         extra_link_args = None
     else:
         extra_compile_args = ["-fopenmp"]
-        extra_link_args = ['-fopenmp']
+        extra_link_args = ["-fopenmp"]
 
     ext_modules = [
         Extension(
-            "openmp_helpers",
-            ["openmp_helpers.pyx"],
+            "openmp_helpers_outer",
+            ["openmp_helpers_outer.pyx"],
             extra_compile_args=extra_compile_args,
             extra_link_args=extra_link_args
             )
     ]
 
     setup(
-        name='_openmp_test_helper',
+        name="_openmp_test_helper_outer",
         ext_modules=cythonize(
             ext_modules,
-            language_level=3),
+            language_level=3,
+            compile_time_env={"CC_OUTER_LOOP": outer_loop_cc_var or "unknown"}),
     )
 
 finally:

--- a/tests/_openmp_test_helper/setup_outer.py
+++ b/tests/_openmp_test_helper/setup_outer.py
@@ -4,19 +4,14 @@ from distutils.core import setup
 from Cython.Build import cythonize
 from distutils.extension import Extension
 
+from build_utils import set_cc_variables
+
 
 original_environ = os.environ.copy()
 try:
     # Make it possible to compile the 2 OpenMP enabled Cython extensions
     # with different compilers and therefore different OpenMP runtimes.
-    outer_loop_cc_var = os.environ.get("CC_OUTER_LOOP")
-    if outer_loop_cc_var is not None:
-        os.environ["CC"] = outer_loop_cc_var
-        if sys.platform == "darwin":
-            os.environ["LDSHARED"] = (
-                outer_loop_cc_var + " -bundle -undefined dynamic_lookup")
-        else:
-            os.environ["LDSHARED"] = outer_loop_cc_var + " -shared"
+    outer_loop_cc_var = set_cc_variables("CC_OUTER_LOOP")
 
     if sys.platform == "win32":
         openmp_flag = ["/openmp"]

--- a/tests/_openmp_test_helper/setup_outer.py
+++ b/tests/_openmp_test_helper/setup_outer.py
@@ -12,21 +12,25 @@ try:
     outer_loop_cc_var = os.environ.get("CC_OUTER_LOOP")
     if outer_loop_cc_var is not None:
         os.environ["CC"] = outer_loop_cc_var
-        os.environ["LDSHARED"] = outer_loop_cc_var + " -shared"
+        if sys.platform == "darwin":
+            os.environ["LDSHARED"] = (
+                outer_loop_cc_var + " -bundle -undefined dynamic_lookup")
+        else:
+            os.environ["LDSHARED"] = outer_loop_cc_var + " -shared"
 
     if sys.platform == "win32":
-        extra_compile_args = ["/openmp"]
-        extra_link_args = None
+        openmp_flag = ["/openmp"]
+    elif sys.platform == "darwin" and 'openmp' in os.getenv('CPPFLAGS', ''):
+        openmp_flag = []
     else:
-        extra_compile_args = ["-fopenmp"]
-        extra_link_args = ["-fopenmp"]
+        openmp_flag = ["-fopenmp"]
 
     ext_modules = [
         Extension(
             "openmp_helpers_outer",
             ["openmp_helpers_outer.pyx"],
-            extra_compile_args=extra_compile_args,
-            extra_link_args=extra_link_args
+            extra_compile_args=openmp_flag,
+            extra_link_args=openmp_flag
             )
     ]
 

--- a/tests/_openmp_test_helper/setup_outer.py
+++ b/tests/_openmp_test_helper/setup_outer.py
@@ -34,8 +34,10 @@ try:
         name="_openmp_test_helper_outer",
         ext_modules=cythonize(
             ext_modules,
-            language_level=3,
-            compile_time_env={"CC_OUTER_LOOP": outer_loop_cc_var or "unknown"}),
+            compiler_directives={'language_level': 3,
+                                 'boundscheck': False,
+                                 'wraparound': False},
+            compile_time_env={"CC_OUTER_LOOP": outer_loop_cc_var or "unknown"})
     )
 
 finally:

--- a/tests/_openmp_test_helper_outer/__init__.py
+++ b/tests/_openmp_test_helper_outer/__init__.py
@@ -1,4 +1,0 @@
-from .openmp_helpers_outer import check_nested_openmp_loops
-
-
-__all__ = ["check_nested_openmp_loops"]

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -201,9 +201,16 @@ def test_openmp_nesting(nthreads_outer):
     # decreased:
     assert outer_num_threads == nthreads
 
-    # The number of threads available in the inner loop should have been set
-    # to 1 so avoid oversubscription and preserve performance:
-    assert inner_num_threads == 1
+    # The number of threads available in the inner loop should have been
+    # set to 1 so avoid oversubscription and preserve performance:
+    if inner_cc != outer_cc:
+        if inner_num_threads != 1:
+            # XXX: this does not always work when nesting independent openmp
+            # implementations. See: https://github.com/jeremiedbb/Nested_OpenMP
+            pytest.xfail("Inner OpenMP num threads was %d instead of 1"
+                         % inner_num_threads)
+    else:
+        assert inner_num_threads == 1
 
     # The state of the original state of all threadpools should have been
     # restored.

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -257,5 +257,9 @@ def test_nested_prange_blas(nthreads_outer):
     assert np.allclose(C, np.dot(A, B.T))
     assert prange_num_threads == nthreads
 
-    for module in threadpool_infos:
+    nested_blas_info = [module for module in threadpool_infos
+                        if module["user_api"] == "blas"]
+
+    assert len(nested_blas_info) >= 1
+    for module in nested_blas_info:
         assert module['num_threads'] == 1

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -190,7 +190,8 @@ def test_openmp_nesting(nthreads_outer):
         # There should be at least 2 OpenMP runtime detected.
         assert len(openmp_infos) >= 2
 
-    with threadpool_limits(limits=1) as threadpoolctx:
+    n_inner = 2
+    with threadpool_limits(limits=n_inner) as threadpoolctx:
         max_threads = threadpoolctx.get_original_num_threads('openmp')
         nthreads = effective_num_threads(nthreads_outer, max_threads)
 
@@ -203,7 +204,7 @@ def test_openmp_nesting(nthreads_outer):
 
     # The number of threads available in the inner loop should have been set
     # to 1 so avoid oversubscription and preserve performance:
-    assert inner_num_threads == 1
+    assert inner_num_threads == n_inner
 
     # The state of the original state of all threadpools should have been
     # restored.

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -36,18 +36,15 @@ def test_threadpool_limits_by_prefix(openblas_present, mkl_present, prefix):
         for module in threadpool_info():
             if should_skip_module(module):
                 continue
-            num_threads, filepath = module["num_threads"], module["filepath"]
             if module["prefix"] == prefix:
-                assert num_threads == 1
+                assert module["num_threads"] == 1
 
     with threadpool_limits(limits={prefix: 3}):
         for module in threadpool_info():
             if should_skip_module(module):
                 continue
-            num_threads, filepath = module["num_threads"], module["filepath"]
-            expected_num_threads = min(3, original_num_threads[filepath])
             if module["prefix"] == prefix:
-                assert num_threads == expected_num_threads
+                assert module["num_threads"] <= 3
 
     assert threadpool_info() == original_infos
 
@@ -62,25 +59,20 @@ def test_set_threadpool_limits_by_api(user_api):
         user_apis = (user_api,)
 
     original_infos = threadpool_info()
-    original_num_threads = {info["filepath"]: info['num_threads']
-                            for info in original_infos}
 
     with threadpool_limits(limits=1, user_api=user_api):
         for module in threadpool_info():
             if should_skip_module(module):
                 continue
-            num_threads, filepath = module["num_threads"], module["filepath"]
             if module["user_api"] in user_apis:
-                assert num_threads == 1
+                assert module["num_threads"] == 1
 
     with threadpool_limits(limits=3, user_api=user_api):
         for module in threadpool_info():
             if should_skip_module(module):
                 continue
-            num_threads, filepath = module["num_threads"], module["filepath"]
-            expected_num_threads = min(3, original_num_threads[filepath])
             if module["user_api"] in user_apis:
-                assert num_threads == expected_num_threads
+                assert module["num_threads"] <= 3
 
     assert threadpool_info() == original_infos
 

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -169,8 +169,7 @@ def test_openmp_nesting(nthreads_outer):
     inner_cc = get_inner_compiler()
     outer_cc = get_outer_compiler()
 
-    print("# no limit")
-    outer_num_threads, inner_num_threads = check_nested_openmp_loops(4)
+    outer_num_threads, inner_num_threads = check_nested_openmp_loops(10)
 
     original_infos = threadpool_info()
     openmp_infos = [info for info in original_infos
@@ -191,13 +190,12 @@ def test_openmp_nesting(nthreads_outer):
         # There should be at least 2 OpenMP runtime detected.
         assert len(openmp_infos) >= 2
 
-    print("# inner openmp loop (%s) limited to 1" % inner_cc)
     with threadpool_limits(limits=1) as threadpoolctx:
         max_threads = threadpoolctx.get_original_num_threads('openmp')
         nthreads = effective_num_threads(nthreads_outer, max_threads)
 
         outer_num_threads, inner_num_threads = \
-            check_nested_openmp_loops(4, nthreads)
+            check_nested_openmp_loops(10, nthreads)
 
     # The number of threads available in the outer loop should not have been
     # decreased:

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -18,8 +18,6 @@ def should_skip_module(module):
 @pytest.mark.parametrize("prefix", _ALL_PREFIXES)
 def test_threadpool_limits_by_prefix(openblas_present, mkl_present, prefix):
     original_infos = threadpool_info()
-    original_num_threads = {info["filepath"]: info['num_threads']
-                            for info in original_infos}
     mkl_found = any([True for info in original_infos
                      if info["prefix"] in ('mkl_rt', 'libmkl_rt')])
     prefix_found = len([info["prefix"] for info in original_infos

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -190,8 +190,7 @@ def test_openmp_nesting(nthreads_outer):
         # There should be at least 2 OpenMP runtime detected.
         assert len(openmp_infos) >= 2
 
-    n_inner = 2
-    with threadpool_limits(limits=n_inner) as threadpoolctx:
+    with threadpool_limits(limits=1) as threadpoolctx:
         max_threads = threadpoolctx.get_original_num_threads('openmp')
         nthreads = effective_num_threads(nthreads_outer, max_threads)
 
@@ -204,7 +203,7 @@ def test_openmp_nesting(nthreads_outer):
 
     # The number of threads available in the inner loop should have been set
     # to 1 so avoid oversubscription and preserve performance:
-    assert inner_num_threads == n_inner
+    assert inner_num_threads == 1
 
     # The state of the original state of all threadpools should have been
     # restored.
@@ -233,25 +232,25 @@ def test_multiple_shipped_openblas():
     test_shipped_openblas()
 
 
-# @pytest.mark.skipif(scipy is None, reason="requires scipy")
-# @pytest.mark.parametrize('nthreads_outer', [None, 1, 2, 4])
-# def test_nested_prange_blas(nthreads_outer):
-#     import numpy as np
-#     from ._openmp_test_helper import check_nested_prange_blas
+@pytest.mark.skipif(scipy is None, reason="requires scipy")
+@pytest.mark.parametrize('nthreads_outer', [None, 1, 2, 4])
+def test_nested_prange_blas(nthreads_outer):
+    import numpy as np
+    from ._openmp_test_helper import check_nested_prange_blas
 
-#     A = np.ones((1000, 10))
-#     B = np.ones((100, 10))
+    A = np.ones((1000, 10))
+    B = np.ones((100, 10))
 
-#     with threadpool_limits(limits=1) as threadpoolctx:
-#         max_threads = threadpoolctx.get_original_num_threads('openmp')
-#         nthreads = effective_num_threads(nthreads_outer, max_threads)
+    with threadpool_limits(limits=1) as threadpoolctx:
+        max_threads = threadpoolctx.get_original_num_threads('openmp')
+        nthreads = effective_num_threads(nthreads_outer, max_threads)
 
-#         result = check_nested_prange_blas(A, B, nthreads)
-#         C, prange_num_threads, threadpool_infos = result
+        result = check_nested_prange_blas(A, B, nthreads)
+        C, prange_num_threads, threadpool_infos = result
 
-#     assert np.allclose(C, np.dot(A, B.T))
-#     assert prange_num_threads == nthreads
+    assert np.allclose(C, np.dot(A, B.T))
+    assert prange_num_threads == nthreads
 
-#     for module in threadpool_infos:
-#         if not should_skip_module(module):
-#             assert module['num_threads'] == 1
+    for module in threadpool_infos:
+        if not should_skip_module(module):
+            assert module['num_threads'] == 1

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -180,14 +180,15 @@ def test_openmp_limit_num_threads(num_threads):
 def test_openmp_nesting():
     # checks that OpenMP effectively uses the number of threads requested by
     # the context manager
-    from ._openmp_test_helper_outer import check_nested_openmp_loops
+    from ._openmp_test_helper import check_nested_openmp_loops
+    from ._openmp_test_helper import get_inner_compiler
+    from ._openmp_test_helper import get_outer_compiler
 
-    # Here we assume that the environment variables that were defined when
-    # building the Cython extensions are still defined the same way when
-    # executing this test.
-    inner_cc = os.environ.get("CC_INNER_LOOP")
-    outer_cc = os.environ.get("CC_OUTER_LOOP")
+    inner_cc = get_inner_compiler()
+    outer_cc = get_outer_compiler()
+
     outer_num_threads, inner_num_threads = check_nested_openmp_loops(10)
+
     openmp_infos = [info for info in threadpool_info()
                     if info["user_api"] == "openmp"]
 

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -191,7 +191,7 @@ def test_openmp_nesting(nthreads_outer):
         assert len(openmp_infos) >= 2
 
     with threadpool_limits(limits=1) as threadpoolctx:
-        max_threads = threadpoolctx.get_original_max_threads('openmp')
+        max_threads = threadpoolctx.get_original_num_threads('openmp')
         nthreads = effective_num_threads(nthreads_outer, max_threads)
 
         outer_num_threads, inner_num_threads = \
@@ -242,7 +242,7 @@ def test_nested_prange_blas(nthreads_outer):
     B = np.ones((100, 10))
 
     with threadpool_limits(limits=1) as threadpoolctx:
-        max_threads = threadpoolctx.get_original_max_threads('openmp')
+        max_threads = threadpoolctx.get_original_num_threads('openmp')
         nthreads = effective_num_threads(nthreads_outer, max_threads)
 
         result = check_nested_prange_blas(A, B, nthreads)

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -190,7 +190,8 @@ def test_openmp_nesting(nthreads_outer):
         # There should be at least 2 OpenMP runtime detected.
         assert len(openmp_infos) >= 2
 
-    with threadpool_limits(limits=1) as threadpoolctx:
+    n_inner = 2
+    with threadpool_limits(limits=n_inner) as threadpoolctx:
         max_threads = threadpoolctx.get_original_num_threads('openmp')
         nthreads = effective_num_threads(nthreads_outer, max_threads)
 
@@ -203,7 +204,7 @@ def test_openmp_nesting(nthreads_outer):
 
     # The number of threads available in the inner loop should have been set
     # to 1 so avoid oversubscription and preserve performance:
-    assert inner_num_threads == 1
+    assert inner_num_threads == n_inner
 
     # The state of the original state of all threadpools should have been
     # restored.
@@ -232,25 +233,25 @@ def test_multiple_shipped_openblas():
     test_shipped_openblas()
 
 
-@pytest.mark.skipif(scipy is None, reason="requires scipy")
-@pytest.mark.parametrize('nthreads_outer', [None, 1, 2, 4])
-def test_nested_prange_blas(nthreads_outer):
-    import numpy as np
-    from ._openmp_test_helper import check_nested_prange_blas
+# @pytest.mark.skipif(scipy is None, reason="requires scipy")
+# @pytest.mark.parametrize('nthreads_outer', [None, 1, 2, 4])
+# def test_nested_prange_blas(nthreads_outer):
+#     import numpy as np
+#     from ._openmp_test_helper import check_nested_prange_blas
 
-    A = np.ones((1000, 10))
-    B = np.ones((100, 10))
+#     A = np.ones((1000, 10))
+#     B = np.ones((100, 10))
 
-    with threadpool_limits(limits=1) as threadpoolctx:
-        max_threads = threadpoolctx.get_original_num_threads('openmp')
-        nthreads = effective_num_threads(nthreads_outer, max_threads)
+#     with threadpool_limits(limits=1) as threadpoolctx:
+#         max_threads = threadpoolctx.get_original_num_threads('openmp')
+#         nthreads = effective_num_threads(nthreads_outer, max_threads)
 
-        result = check_nested_prange_blas(A, B, nthreads)
-        C, prange_num_threads, threadpool_infos = result
+#         result = check_nested_prange_blas(A, B, nthreads)
+#         C, prange_num_threads, threadpool_infos = result
 
-    assert np.allclose(C, np.dot(A, B.T))
-    assert prange_num_threads == nthreads
+#     assert np.allclose(C, np.dot(A, B.T))
+#     assert prange_num_threads == nthreads
 
-    for module in threadpool_infos:
-        if not should_skip_module(module):
-            assert module['num_threads'] == 1
+#     for module in threadpool_infos:
+#         if not should_skip_module(module):
+#             assert module['num_threads'] == 1

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -143,18 +143,18 @@ def test_threadpool_limits_bad_input():
         threadpool_limits(limits=(1, 2, 3))
 
 
-# @with_check_openmp_num_threads
-# @pytest.mark.parametrize('num_threads', [1, 2, 4])
-# def test_openmp_limit_num_threads(num_threads):
-#     # checks that OpenMP effectively uses the number of threads requested by
-#     # the context manager
-#     from ._openmp_test_helper import check_openmp_num_threads
+@with_check_openmp_num_threads
+@pytest.mark.parametrize('num_threads', [1, 2, 4])
+def test_openmp_limit_num_threads(num_threads):
+    # checks that OpenMP effectively uses the number of threads requested by
+    # the context manager
+    from ._openmp_test_helper import check_openmp_num_threads
 
-#     old_num_threads = check_openmp_num_threads(100)
+    old_num_threads = check_openmp_num_threads(100)
 
-#     with threadpool_limits(limits=num_threads):
-#         assert check_openmp_num_threads(100) in (num_threads, old_num_threads)
-#     assert check_openmp_num_threads(100) == old_num_threads
+    with threadpool_limits(limits=num_threads):
+        assert check_openmp_num_threads(100) in (num_threads, old_num_threads)
+    assert check_openmp_num_threads(100) == old_num_threads
 
 
 @with_check_openmp_num_threads
@@ -190,8 +190,7 @@ def test_openmp_nesting(nthreads_outer):
         # There should be at least 2 OpenMP runtime detected.
         assert len(openmp_infos) >= 2
 
-    n_inner = 2
-    with threadpool_limits(limits=n_inner) as threadpoolctx:
+    with threadpool_limits(limits=1) as threadpoolctx:
         max_threads = threadpoolctx.get_original_num_threads('openmp')
         nthreads = effective_num_threads(nthreads_outer, max_threads)
 
@@ -204,7 +203,7 @@ def test_openmp_nesting(nthreads_outer):
 
     # The number of threads available in the inner loop should have been set
     # to 1 so avoid oversubscription and preserve performance:
-    assert inner_num_threads == n_inner
+    assert inner_num_threads == 1
 
     # The state of the original state of all threadpools should have been
     # restored.

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -236,13 +236,6 @@ def test_multiple_shipped_openblas():
 @pytest.mark.parametrize('nthreads_outer', [None, 1, 2, 4])
 def test_nested_prange_blas(nthreads_outer):
     import numpy as np
-
-    for module in threadpool_info():
-        if should_skip_module(module):
-            # OpenBLAS 0.3.3 and older are known to cause an unrecoverable
-            # deadlock at process shutdown time (after pytest has exited).
-            pytest.skip("Old OpenBLAS: skipping test to avoid deadlock")
-
     from ._openmp_test_helper import check_nested_prange_blas
     A = np.ones((1000, 10))
     B = np.ones((100, 10))
@@ -254,8 +247,16 @@ def test_nested_prange_blas(nthreads_outer):
         result = check_nested_prange_blas(A, B, nthreads)
         C, prange_num_threads, threadpool_infos = result
 
-    assert np.allclose(C, np.dot(A, B.T))
+    old_openblas = any(should_skip_module(module)
+                       for module in threadpool_infos)
+    if not old_openblas:
+        # OpenBLAS 0.3.3 and older are known to cause an unrecoverable
+        # deadlock at process shutdown time (after pytest has exited) if the
+        # following dot product is computed with numpy:
+        assert np.allclose(C, np.dot(A, B.T))
+
     assert prange_num_threads == nthreads
 
     for module in threadpool_infos:
-        assert module['num_threads'] == 1
+        if not should_skip_module(module):
+            assert module['num_threads'] == 1

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -169,7 +169,8 @@ def test_openmp_nesting(nthreads_outer):
     inner_cc = get_inner_compiler()
     outer_cc = get_outer_compiler()
 
-    outer_num_threads, inner_num_threads = check_nested_openmp_loops(10)
+    print("# no limit")
+    outer_num_threads, inner_num_threads = check_nested_openmp_loops(4)
 
     original_infos = threadpool_info()
     openmp_infos = [info for info in original_infos
@@ -190,12 +191,13 @@ def test_openmp_nesting(nthreads_outer):
         # There should be at least 2 OpenMP runtime detected.
         assert len(openmp_infos) >= 2
 
+    print("# inner openmp loop (%s) limited to 1" % inner_cc)
     with threadpool_limits(limits=1) as threadpoolctx:
         max_threads = threadpoolctx.get_original_num_threads('openmp')
         nthreads = effective_num_threads(nthreads_outer, max_threads)
 
         outer_num_threads, inner_num_threads = \
-            check_nested_openmp_loops(10, nthreads)
+            check_nested_openmp_loops(4, nthreads)
 
     # The number of threads available in the outer loop should not have been
     # decreased:

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -8,7 +8,12 @@ from threadpoolctl import _ALL_PREFIXES, _ALL_USER_APIS
 
 from .utils import with_check_openmp_num_threads
 from .utils import libopenblas_paths
-from .utils import scipy_available
+from .utils import scipy
+
+
+from threading import Timer
+import faulthandler
+Timer(1, faulthandler.dump_traceback).start()
 
 
 def should_skip_module(module):
@@ -232,7 +237,7 @@ def test_multiple_shipped_openblas():
     test_shipped_openblas()
 
 
-@pytest.mark.skipif(not scipy_available(), reason="requires scipy")
+@pytest.mark.skipif(scipy is None, reason="requires scipy")
 @pytest.mark.parametrize('nthreads_outer', [None, 1, 2, 4])
 def test_nested_prange_blas(nthreads_outer):
     import numpy as np

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -224,3 +224,20 @@ def test_multiple_shipped_openblas():
     # has 2 or more active openblas runtimes available just be reading the
     # pytest report (whether or not this test has been skipped).
     test_shipped_openblas()
+
+
+@pytest.mark.parametrize('nthreads_outer', [1, 2, 4])
+def test_nested_prange_blas(nthreads_outer):
+    import numpy as np
+    from ._openmp_test_helper import check_nested_prange_blas
+
+    A = np.ones((1000, 10))
+    B = np.ones((100, 10))
+
+    with threadpool_limits(limits=1):
+        result = check_nested_prange_blas(A, B, nthreads_outer)
+        C, prange_num_threads, blas_num_threads = result
+
+    assert prange_num_threads == nthreads_outer
+    assert all(b_n_t == 1 for b_n_t in blas_num_threads)
+    assert np.allclose(C, np.dot(A, B.T))

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -236,8 +236,14 @@ def test_multiple_shipped_openblas():
 @pytest.mark.parametrize('nthreads_outer', [None, 1, 2, 4])
 def test_nested_prange_blas(nthreads_outer):
     import numpy as np
-    from ._openmp_test_helper import check_nested_prange_blas
 
+    for module in threadpool_info():
+        if should_skip_module(module):
+            # OpenBLAS 0.3.3 and older are known to cause an unrecoverable
+            # deadlock at process shutdown time (after pytest has exited).
+            pytest.skip("Old OpenBLAS: skipping test to avoid deadlock")
+
+    from ._openmp_test_helper import check_nested_prange_blas
     A = np.ones((1000, 10))
     B = np.ones((100, 10))
 
@@ -252,5 +258,4 @@ def test_nested_prange_blas(nthreads_outer):
     assert prange_num_threads == nthreads
 
     for module in threadpool_infos:
-        if not should_skip_module(module):
-            assert module['num_threads'] == 1
+        assert module['num_threads'] == 1

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -36,7 +36,7 @@ def test_threadpool_limits_by_prefix(openblas_present, mkl_present, prefix):
         elif prefix == "libopenblas" and openblas_present:
             raise RuntimeError("Could not load the OpenBLAS prefix")
         else:
-            pytest.skip("Need {} support".format(prefix))
+            pytest.skip("{} runtime missing".format(prefix))
 
     with threadpool_limits(limits={prefix: 1}):
         for module in threadpool_info():

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -11,11 +11,6 @@ from .utils import libopenblas_paths
 from .utils import scipy
 
 
-from threading import Timer
-import faulthandler
-Timer(1, faulthandler.dump_traceback).start()
-
-
 def should_skip_module(module):
     # Possible bug in getting maximum number of threads with OpenBLAS < 0.2.16
     # and OpenBLAS does not expose its version before 0.3.4.
@@ -148,18 +143,18 @@ def test_threadpool_limits_bad_input():
         threadpool_limits(limits=(1, 2, 3))
 
 
-@with_check_openmp_num_threads
-@pytest.mark.parametrize('num_threads', [1, 2, 4])
-def test_openmp_limit_num_threads(num_threads):
-    # checks that OpenMP effectively uses the number of threads requested by
-    # the context manager
-    from ._openmp_test_helper import check_openmp_num_threads
+# @with_check_openmp_num_threads
+# @pytest.mark.parametrize('num_threads', [1, 2, 4])
+# def test_openmp_limit_num_threads(num_threads):
+#     # checks that OpenMP effectively uses the number of threads requested by
+#     # the context manager
+#     from ._openmp_test_helper import check_openmp_num_threads
 
-    old_num_threads = check_openmp_num_threads(100)
+#     old_num_threads = check_openmp_num_threads(100)
 
-    with threadpool_limits(limits=num_threads):
-        assert check_openmp_num_threads(100) in (num_threads, old_num_threads)
-    assert check_openmp_num_threads(100) == old_num_threads
+#     with threadpool_limits(limits=num_threads):
+#         assert check_openmp_num_threads(100) in (num_threads, old_num_threads)
+#     assert check_openmp_num_threads(100) == old_num_threads
 
 
 @with_check_openmp_num_threads

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -237,6 +237,8 @@ def test_multiple_shipped_openblas():
 def test_nested_prange_blas(nthreads_outer):
     import numpy as np
 
+    blas_info = [module for module in threadpool_info()
+                 if module["user_api"] == "blas"]
     for module in threadpool_info():
         if should_skip_module(module):
             # OpenBLAS 0.3.3 and older are known to cause an unrecoverable
@@ -260,6 +262,6 @@ def test_nested_prange_blas(nthreads_outer):
     nested_blas_info = [module for module in threadpool_infos
                         if module["user_api"] == "blas"]
 
-    assert len(nested_blas_info) >= 1
+    assert len(nested_blas_info) == len(blas_info)
     for module in nested_blas_info:
         assert module['num_threads'] == 1

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,11 +29,12 @@ except ImportError:
 try:
     import scipy
     import scipy.linalg  # noqa: F401
+    scipy.linalg.svd([[1, 2], [3, 4]])
 
     libopenblas_patterns.append(os.path.join(scipy.__path__[0], ".libs",
                                              "libopenblas*"))
 except ImportError:
-    pass
+    scipy = None
 
 libopenblas_paths = set(path for pattern in libopenblas_patterns
                         for path in glob(pattern))
@@ -53,12 +54,3 @@ except ImportError:
         """A decorator to skip tests if check_openmp_n_threads is not compiled.
         """
         return skip_func('Test requires check_openmp_n_threads to be compiled')
-
-
-# helper to skip test is scipy not installed
-def scipy_available():
-    try:
-        import scipy  # noqa
-        return True
-    except ImportError:
-        return False

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -53,3 +53,12 @@ except ImportError:
         """A decorator to skip tests if check_openmp_n_threads is not compiled.
         """
         return skip_func('Test requires check_openmp_n_threads to be compiled')
+
+
+# helper to skip test is scipy not installed
+def scipy_available():
+    try:
+        import scipy  # noqa
+        return True
+    except ImportError:
+        return False

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -180,9 +180,12 @@ def _set_threadpool_limits(limits, user_api=None):
 
     modules = _load_modules(prefixes=prefixes, user_api=user_api)
     for module in modules:
-        num_threads = _get_limit(module['prefix'], module['user_api'], limits)
-        module['num_threads'] = module['get_num_threads']()
+        # Workaround clang bug (TODO: report it)
+        module['get_num_threads']()
 
+    for module in modules:
+        module['num_threads'] = module['get_num_threads']()
+        num_threads = _get_limit(module['prefix'], module['user_api'], limits)
         if num_threads is not None:
             set_func = module['set_num_threads']
             set_func(num_threads)

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -17,7 +17,7 @@ import ctypes
 from ctypes.util import find_library
 
 __version__ = '1.0.0.dev0'
-__all__ = ["threadpool_limits", "threadpool_info"]
+__all__ = ["threadpool_limits", "threadpool_info", "safe_nested_parallelism"]
 
 # Cache for libc under POSIX and a few system libraries under Windows
 _system_libraries = {}
@@ -510,3 +510,52 @@ class threadpool_limits:
         if self._original_limits is not None:
             for module in self._original_limits:
                 module['set_num_threads'](module['num_threads'])
+
+
+class safe_nested_parallelism:
+    """Context manager to ensure that the inner parallel loop run serially
+
+    This makes it possible to nest calls with libraries built with independent
+    threadpool runtimes without causing oversubscription.
+    """
+
+    def __init__(self, outer_module, outer_api, inner_module, inner_api):
+        if hasattr(outer_module, "__file__"):
+            outer_module = outer_module.__file__
+        outer_lib = ctypes.cdll[outer_module]
+        outer_api = _MAP_API_TO_FUNC[outer_api]
+        if hasattr(inner_module, "__file__"):
+            inner_module = inner_module.__file__
+        inner_lib = ctypes.cdll[inner_module]
+        inner_api = _MAP_API_TO_FUNC[inner_api]
+
+        outer_get_num_threads = outer_lib[outer_api["get_num_threads"]]
+        inner_get_num_threads = inner_lib[inner_api["get_num_threads"]]
+        self._inner_set_num_threads = inner_lib[inner_api["set_num_threads"]]
+
+        outer_num_threads = outer_get_num_threads()
+        inner_num_threads = inner_get_num_threads()
+        self._original_inner_num_threads = None
+        if inner_num_threads >= 1:
+            # Switch to serial mode
+            self._inner_set_num_threads(1)
+            if outer_get_num_threads() < outer_num_threads:
+                # The two thread pools are tied (or the same). We do not need
+                # any oversubscription protection. Let's restore the previous
+                # state of the threadpool right away:
+                self._inner_set_num_threads(inner_num_threads)
+            else:
+                # The protection is now in-place. Record the original number
+                # of threads of the inner thread pool to be able to restore it
+                # in the unregister method.
+                self._original_inner_num_threads = inner_num_threads
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, type, value, traceback):
+        self.unregister()
+
+    def unregister(self):
+        if self._original_inner_num_threads is not None:
+            self._inner_set_num_threads(self._original_inner_num_threads)

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -522,7 +522,7 @@ class threadpool_limits:
         n_limits = len(limits)
 
         if n_limits == 1:
-            return limits[0]
+            return limits.pop()
         elif n_limits == 0:
             return None
         else:

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -308,7 +308,9 @@ def _make_module_info(filepath, module_info, prefix):
 
 
 def _get_module_info_from_path(filepath, prefixes, user_api, modules):
-    filename = os.path.basename(filepath)
+    # `lower` required to take account of OpenMP dll case on Windows
+    # (vcomp, VCOMP, Vcomp, ...)
+    filename = os.path.basename(filepath).lower()
     for info in _SUPPORTED_IMPLEMENTATIONS:
         prefix = _check_prefix(filename, info['filename_prefixes'])
         if _match_module(info, prefix, prefixes, user_api):

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -539,6 +539,8 @@ class safe_nested_parallelism:
         if inner_num_threads >= 1:
             # Switch to serial mode
             self._inner_set_num_threads(1)
+            assert inner_get_num_threads() == 1
+
             if outer_get_num_threads() < outer_num_threads:
                 # The two thread pools are tied (or the same). We do not need
                 # any oversubscription protection. Let's restore the previous


### PR DESCRIPTION
As discussed there https://github.com/joblib/threadpoolctl/issues/14#issuecomment-478652588 .

For now here is some test infrastructure that highlight the problem with 2 OpenMP enabled Cython extensions.