### PR TITLE
Set env vars to work around multiple OpenMP runtimes bug

### DIFF
--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -197,23 +197,26 @@ def test_openmp_nesting(nthreads_outer):
         outer_num_threads, inner_num_threads = \
             check_nested_openmp_loops(10, nthreads)
 
+        # The number of threads available in the outer loop should not have
+        # been decreased. Inner should have been set to 1.
+        assert outer_num_threads == nthreads
+        assert inner_num_threads == 1
+
+    with threadpool_limits(limits=2) as threadpoolctx:
+        max_threads = threadpoolctx.get_original_num_threads('openmp')
+        nthreads = effective_num_threads(nthreads_outer, max_threads)
+
+        outer_num_threads, inner_num_threads = \
+            check_nested_openmp_loops(10, nthreads)
+
+        # The number of threads available in the outer loop should not have
+        # been decreased. Inner should be at most 2.
+        assert outer_num_threads == nthreads
+        assert inner_num_threads == 2
+
     # The state of the original state of all threadpools should have been
     # restored.
     assert threadpool_info() == original_infos
-
-    # The number of threads available in the outer loop should not have been
-    # decreased:
-    assert outer_num_threads == nthreads
-
-    # The number of threads available in the inner loop should have been
-    # set to 1 so avoid oversubscription and preserve performance:
-    if inner_cc != outer_cc:
-        if inner_num_threads != 1:
-            # XXX: this does not always work when nesting independent openmp
-            # implementations. See: https://github.com/jeremiedbb/Nested_OpenMP
-            pytest.xfail("Inner OpenMP num threads was %d instead of 1"
-                         % inner_num_threads)
-    assert inner_num_threads == 1
 
 
 def test_shipped_openblas():

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -212,7 +212,7 @@ def test_openmp_nesting(nthreads_outer):
         # The number of threads available in the outer loop should not have
         # been decreased. Inner should be at most 2.
         assert outer_num_threads == nthreads
-        assert inner_num_threads == 2
+        assert inner_num_threads <= 2
 
     # The state of the original state of all threadpools should have been
     # restored.

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -200,10 +200,8 @@ def _set_threadpool_limits(limits, user_api=None):
     for module in modules:
         module['num_threads'] = module['get_num_threads']()
         num_threads = _get_limit(module['prefix'], module['user_api'], limits)
-        if num_threads is not None:
-            set_func = module['set_num_threads']
-            set_func(num_threads)
 
+        # limit through environment variables
         module_var = module['environ_name']
         if environ_vars is not None and module_var in environ_vars:
             if environ_vars[module_var] is not None:
@@ -212,6 +210,11 @@ def _set_threadpool_limits(limits, user_api=None):
                 os.environ.pop(module_var, None)
         else:
             os.environ[module['environ_name']] = str(num_threads)
+
+        # limit through api
+        if num_threads is not None:
+            set_func = module['set_num_threads']
+            set_func(num_threads)
 
     return modules
 


### PR DESCRIPTION
Add a `environ_name` field for the supported apis which contains the corresponding env var to control the number of threads:
`MKL_NUM_THREADS`, `OPENBLAS_NUM_THREADS` or `OMP_NUM_THREADS`.

Set those in addition to using the omp_set function. This is a work around for an OpenMP bug(?) when doing nested parallelism with different OpenMP runtimes. With the omp_set functions, only the number of threads in the master thread of the outer loop would be impacted.