### PR TITLE
[MRG] ENH Add BLIS support

### DIFF
--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -73,6 +73,19 @@ jobs:
         VERSION_PYTHON: '*'
         CC_OUTER_LOOP: 'gcc'
         CC_INNER_LOOP: 'clang-8'
+      # Linux environment with numpy linked to BLIS
+      pylatest_blis_gcc_clang:
+        PACKAGER: 'conda'
+        VERSION_PYTHON: '*'
+        INSTALL_BLIS: 'true'
+        CC_OUTER_LOOP: 'gcc'
+        BLIS_CC: 'clang-8'
+      pylatest_blis_clang_gcc:
+        PACKAGER: 'conda'
+        VERSION_PYTHON: '*'
+        INSTALL_BLIS: 'true'
+        CC_OUTER_LOOP: 'clang-8'
+        BLIS_CC: 'gcc'
 
 - template: continuous_integration/posix.yml
   parameters:

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -78,13 +78,22 @@ jobs:
         PACKAGER: 'conda'
         VERSION_PYTHON: '*'
         INSTALL_BLIS: 'true'
+        BLIS_NUM_THREADS: '4'
         CC_OUTER_LOOP: 'gcc'
         BLIS_CC: 'clang-8'
       pylatest_blis_clang_gcc:
         PACKAGER: 'conda'
         VERSION_PYTHON: '*'
         INSTALL_BLIS: 'true'
+        BLIS_NUM_THREADS: '4'
         CC_OUTER_LOOP: 'clang-8'
+        BLIS_CC: 'gcc'
+      pylatest_blis_sinlge_threaded:
+        PACKAGER: 'conda'
+        VERSION_PYTHON: '*'
+        INSTALL_BLIS: 'true'
+        BLIS_NUM_THREADS: '1'
+        CC_OUTER_LOOP: 'gcc'
         BLIS_CC: 'gcc'
 
 - template: continuous_integration/posix.yml

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -80,6 +80,7 @@ jobs:
         INSTALL_BLIS: 'true'
         BLIS_NUM_THREADS: '4'
         CC_OUTER_LOOP: 'gcc'
+        CC_INNER_LOOP: 'gcc'
         BLIS_CC: 'clang-8'
       pylatest_blis_clang_gcc:
         PACKAGER: 'conda'
@@ -87,6 +88,7 @@ jobs:
         INSTALL_BLIS: 'true'
         BLIS_NUM_THREADS: '4'
         CC_OUTER_LOOP: 'clang-8'
+        CC_INNER_LOOP: 'clang-8'
         BLIS_CC: 'gcc'
       pylatest_blis_sinlge_threaded:
         PACKAGER: 'conda'
@@ -94,6 +96,7 @@ jobs:
         INSTALL_BLIS: 'true'
         BLIS_NUM_THREADS: '1'
         CC_OUTER_LOOP: 'gcc'
+        CC_INNER_LOOP: 'gcc'
         BLIS_CC: 'gcc'
 
 - template: continuous_integration/posix.yml

--- a/continuous_integration/install_with_blis.sh
+++ b/continuous_integration/install_with_blis.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+pushd ..
+ABS_PATH=$(pwd)
+popd
+
+# Assume Ubuntu: install a recent version of clang and libomp
+echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
+echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+sudo apt update
+sudo apt install clang-8 libomp-8-dev
+
+# create conda env
+conda create -n $VIRTUALENV -q --yes python=$VERSION_PYTHON pip cython
+source activate $VIRTUALENV
+
+pushd ..
+
+# build & install blis
+mkdir BLIS_install
+git clone https://github.com/flame/blis.git
+pushd blis
+./configure --prefix=$ABS_PATH/BLIS_install --enable-cblas --enable-threading=openmp CC=$BLIS_CC auto
+make -j4
+make install
+popd
+
+# build & install numpy
+git clone https://github.com/numpy/numpy.git
+pushd numpy
+echo "[blis]
+libraries = blis
+library_dirs = $ABS_PATH/BLIS_install/lib
+include_dirs = $ABS_PATH/BLIS_install/include/blis
+runtime_library_dirs = $ABS_PATH/BLIS_install/lib" > site.cfg
+python setup.py build_ext -i
+pip install -e .
+popd
+
+popd
+
+python -m pip install -q -r dev-requirements.txt
+CFLAGS=-I$ABS_PATH/BLIS_install/include/blis LDFLAGS=-L$ABS_PATH/BLIS_install/lib \
+    bash ./continuous_integration/build_test_ext.sh
+
+python --version
+python -c "import numpy; print('numpy %s' % numpy.__version__)" || echo "no numpy"
+python -c "import scipy; print('scipy %s' % scipy.__version__)" || echo "no scipy"
+
+python -m flit install --symlink

--- a/continuous_integration/posix.yml
+++ b/continuous_integration/posix.yml
@@ -21,7 +21,7 @@ jobs:
       condition: ne(variables['INSTALL_BLIS'], 'true')
     - script: |
         continuous_integration/install_with_blis.sh
-      displayName: 'Install'
+      displayName: 'Install with BLIS'
       condition: eq(variables['INSTALL_BLIS'], 'true')
     - script: |
         continuous_integration/test_script.sh

--- a/continuous_integration/posix.yml
+++ b/continuous_integration/posix.yml
@@ -18,6 +18,11 @@ jobs:
     - script: |
         continuous_integration/install.sh
       displayName: 'Install'
+      condition: ne(variables['INSTALL_BLIS'], 'true')
+    - script: |
+        continuous_integration/install_with_blis.sh
+      displayName: 'Install'
+      condition: eq(variables['INSTALL_BLIS'], 'true')
     - script: |
         continuous_integration/test_script.sh
       displayName: 'Test Library'

--- a/continuous_integration/posix.yml
+++ b/continuous_integration/posix.yml
@@ -17,7 +17,7 @@ jobs:
       condition: or(eq(variables['PACKAGER'], 'conda'), eq(variables['PACKAGER'], 'pip'))
     - script: |
         continuous_integration/install.sh
-      displayName: 'Install'
+      displayName: 'Install without BLIS'
       condition: ne(variables['INSTALL_BLIS'], 'true')
     - script: |
         continuous_integration/install_with_blis.sh

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -11,6 +11,11 @@ elif [[ "$PACKAGER" == "ubuntu" ]]; then
     source $VIRTUALENV/bin/activate
 fi
 
+# by default BLIS is single-threaded. Enable multi-threading to run the tests
+if [[ "$INSTALL_BLIS" == "true" ]]; then
+    export BLIS_NUM_THREADS=4
+fi
+
 set -x
 PYTHONPATH="." python continuous_integration/display_versions.py
 

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -11,11 +11,6 @@ elif [[ "$PACKAGER" == "ubuntu" ]]; then
     source $VIRTUALENV/bin/activate
 fi
 
-# by default BLIS is single-threaded. Enable multi-threading to run the tests
-if [[ "$INSTALL_BLIS" == "true" ]]; then
-    export BLIS_NUM_THREADS=4
-fi
-
 set -x
 PYTHONPATH="." python continuous_integration/display_versions.py
 

--- a/tests/_openmp_test_helper/nested_prange_blas.pyx
+++ b/tests/_openmp_test_helper/nested_prange_blas.pyx
@@ -17,7 +17,7 @@ IF USE_BLIS:
             CBLAS_TRANSPOSE TransB, int M, int N,
             int K, double alpha, double *A, int lda,
             double *B, int ldb, double beta, double *C, int ldc)
-ELSE: 
+ELSE:
     from scipy.linalg.cython_blas cimport dgemm
 
 from threadpoolctl import threadpool_info
@@ -49,7 +49,7 @@ def check_nested_prange_blas(double[:, ::1] A, double[:, ::1] B, int nthreads):
         if openmp.omp_get_thread_num() == 0:
             with gil:
                 threadpool_infos[0] = threadpool_info()
-            
+
             prange_num_threads_ptr[0] = openmp.omp_get_num_threads()
 
         for i in prange(n_chunks):

--- a/tests/_openmp_test_helper/setup_nested_prange_blas.py
+++ b/tests/_openmp_test_helper/setup_nested_prange_blas.py
@@ -12,12 +12,16 @@ try:
     set_cc_variables("CC_OUTER_LOOP")
     openmp_flag = get_openmp_flag()
 
+    use_blis = os.getenv('INSTALL_BLIS', False)
+    libraries = ['blis'] if use_blis else []
+
     ext_modules = [
         Extension(
             "nested_prange_blas",
             ["nested_prange_blas.pyx"],
             extra_compile_args=openmp_flag,
-            extra_link_args=openmp_flag
+            extra_link_args=openmp_flag,
+            libraries=libraries
             )
     ]
 
@@ -25,6 +29,7 @@ try:
         name='_openmp_test_helper_nested_prange_blas',
         ext_modules=cythonize(
             ext_modules,
+            compile_time_env={'USE_BLIS': use_blis},
             compiler_directives={'language_level': 3,
                                  'boundscheck': False,
                                  'wraparound': False})

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -273,6 +273,7 @@ def test_nested_prange_blas(nthreads_outer):
 
     nested_blas_info = [module for module in threadpool_infos
                         if module["user_api"] == "blas"]
+
     assert len(nested_blas_info) == len(blas_info)
     for module in nested_blas_info:
         assert module['num_threads'] == 1

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -271,10 +271,8 @@ def test_nested_prange_blas(nthreads_outer):
     assert np.allclose(C, np.dot(A, B.T))
     assert prange_num_threads == nthreads
 
-    for thread_infos in threadpool_infos:
-        nested_blas_info = [module for module in thread_infos
-                            if module["user_api"] == "blas"]
-
-        assert len(nested_blas_info) == len(blas_info)
-        for module in nested_blas_info:
-            assert module['num_threads'] == 1
+    nested_blas_info = [module for module in threadpool_infos
+                        if module["user_api"] == "blas"]
+    assert len(nested_blas_info) == len(blas_info)
+    for module in nested_blas_info:
+        assert module['num_threads'] == 1

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -74,6 +74,11 @@ _SUPPORTED_IMPLEMENTATIONS = [
         "internal_api": "mkl",
         "filename_prefixes": ("libmkl_rt", "mkl_rt",),
     },
+    {
+        "user_api": "blas",
+        "internal_api": "blis",
+        "filename_prefixes": ("libblis",),
+    },
 ]
 
 # map a internal_api (openmp, openblas, mkl) to set and get functions
@@ -88,6 +93,9 @@ _MAP_API_TO_FUNC = {
     "mkl": {
         "set_num_threads": "MKL_Set_Num_Threads",
         "get_num_threads": "MKL_Get_Max_Threads"},
+    "blis": {
+        "set_num_threads": "bli_thread_set_num_threads",
+        "get_num_threads": "bli_thread_get_num_threads"}
 }
 
 # Helpers for the doc and test names
@@ -227,6 +235,8 @@ def _get_version(dynlib, internal_api):
         return None
     elif internal_api == "openblas":
         return _get_openblas_version(dynlib)
+    elif internal_api == "blis":
+        return _get_blis_version(dynlib)
     else:
         raise NotImplementedError("Unsupported API {}".format(internal_api))
 
@@ -255,6 +265,13 @@ def _get_openblas_version(openblas_dynlib):
     if config[0] == b"OpenBLAS":
         return config[1].decode('utf-8')
     return None
+
+
+def _get_blis_version(blis_dynlib):
+    """Return the BLIS version"""
+    get_version = getattr(blis_dynlib, "bli_info_get_version_str")
+    get_version.restype = ctypes.c_char_p
+    return get_version().decode('utf-8')
 
 
 # Loading utilities for dynamically linked shared objects

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -218,6 +218,10 @@ def threadpool_info():
     modules = _load_modules(user_api=_ALL_USER_APIS)
     for module in modules:
         module['num_threads'] = module['get_num_threads']()
+        # by default BLIS is single-threaded and get_num_threads returns -1.
+        # we map it to 1 for consistency with other libraries.
+        if module['num_threads'] == -1 and module['internal_api'] == 'blis':
+            module['num_threads'] = 1
         # Remove the wrapper for the module and its function
         del module['set_num_threads'], module['get_num_threads']
         del module['dynlib']

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -287,13 +287,18 @@ def _load_modules(prefixes=None, user_api=None):
     if user_api is None:
         user_api = []
     if sys.platform == "darwin":
-        return _find_modules_with_dyld(prefixes=prefixes, user_api=user_api)
+        modules = _find_modules_with_dyld(prefixes=prefixes, user_api=user_api)
     elif sys.platform == "win32":
-        return _find_modules_with_enum_process_module_ex(
+        modules = _find_modules_with_enum_process_module_ex(
             prefixes=prefixes, user_api=user_api)
     else:
-        return _find_modules_with_dl_iterate_phdr(
+        modules = _find_modules_with_dl_iterate_phdr(
             prefixes=prefixes, user_api=user_api)
+    
+    def lib_order(module):
+        return 1 if module['internal_api'] == 'openmp' else 0
+
+    return sorted(modules, key=lib_order)
 
 
 def _check_prefix(library_basename, filename_prefixes):

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -118,9 +118,8 @@ def _format_docstring(*args, **kwargs):
 def _get_limit(prefix, user_api, limits):
     if prefix in limits:
         return limits[prefix]
-    if user_api in limits:
+    else:
         return limits[user_api]
-    return None
 
 
 @_format_docstring(ALL_PREFIXES=_ALL_PREFIXES,

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -287,18 +287,13 @@ def _load_modules(prefixes=None, user_api=None):
     if user_api is None:
         user_api = []
     if sys.platform == "darwin":
-        modules = _find_modules_with_dyld(prefixes=prefixes, user_api=user_api)
+        return _find_modules_with_dyld(prefixes=prefixes, user_api=user_api)
     elif sys.platform == "win32":
-        modules = _find_modules_with_enum_process_module_ex(
+        return _find_modules_with_enum_process_module_ex(
             prefixes=prefixes, user_api=user_api)
     else:
-        modules = _find_modules_with_dl_iterate_phdr(
+        return _find_modules_with_dl_iterate_phdr(
             prefixes=prefixes, user_api=user_api)
-    
-    def lib_order(module):
-        return 1 if module['internal_api'] == 'openmp' else 0
-
-    return sorted(modules, key=lib_order)
 
 
 def _check_prefix(library_basename, filename_prefixes):


### PR DESCRIPTION
Fixes #15

By default, BLIS is sequential and `num_threads` will be -1 in the infos.
It can be a bit confusing since -1 means all cores sometimes, e.g. sklearn. I think we should map -1 to +1. wdyt ?