### PR TITLE
COV: Fully disable threading of BLIS to improve coverage

### DIFF
--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -90,7 +90,7 @@ jobs:
         CC_OUTER_LOOP: 'clang-8'
         CC_INNER_LOOP: 'clang-8'
         BLIS_CC: 'gcc'
-      pylatest_blis_sinlge_threaded:
+      pylatest_blis_no_threading:
         PACKAGER: 'conda'
         VERSION_PYTHON: '*'
         INSTALL_BLIS: 'true'

--- a/continuous_integration/install_with_blis.sh
+++ b/continuous_integration/install_with_blis.sh
@@ -23,7 +23,12 @@ pushd ..
 mkdir BLIS_install
 git clone https://github.com/flame/blis.git
 pushd blis
-./configure --prefix=$ABS_PATH/BLIS_install --enable-cblas --enable-threading=openmp CC=$BLIS_CC auto
+if [[ "$BLIS_NUM_THREADS" == "1" ]]; then
+    THREADING='no'
+else
+    THREADING='openmp'
+fi
+./configure --prefix=$ABS_PATH/BLIS_install --enable-cblas --enable-threading=$THREADING CC=$BLIS_CC auto
 make -j4
 make install
 popd


### PR DESCRIPTION
Wrong interpretation of the coverage report made me believe that the special case for `module['num_threads']` for BLIS in no threading mode was covered but actually it was not.