### PR TITLE
[WIP] Make it possible to set limits from already loaded modules

### DIFF
--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -18,7 +18,7 @@ make_conda() {
     if [[ "$UNAMESTR" == "Darwin" ]]; then
         if [[ "$INSTALL_LIBOMP" == "conda-forge" ]]; then
             # Install an OpenMP-enabled clang/llvm from conda-forge
-            TO_INSTALL="$TO_INSTALL conda-forge::compilers"
+            TO_INSTALL="$TO_INSTALL conda-forge::compilers conda-forge::llvm-openmp"
             export CFLAGS="$CFLAGS -I$CONDA/envs/$VIRTUALENV/include"
             export LDFLAGS="$LDFLAGS -Wl,-rpath,$CONDA/envs/$VIRTUALENV/lib -L$CONDA/envs/$VIRTUALENV/lib"
 

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -14,4 +14,4 @@ fi
 set -x
 PYTHONPATH="." python continuous_integration/display_versions.py
 
-pytest -vlrxXs --junitxml=$JUNITXML --cov=threadpoolctl
+pytest -vlrxXs -vv --junitxml=$JUNITXML --cov=threadpoolctl

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -39,7 +39,6 @@ def get_module_from_path(modules, path):
 def test_threadpool_limits_by_prefix(openblas_present, mkl_present,
                                      use_infos, prefix):
     original_infos = threadpool_info(return_api=use_infos)
-    print(original_infos)
     original_infos_or_none = original_infos if use_infos else None
 
     mkl_found = any([True for info in original_infos

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -39,6 +39,7 @@ def get_module_from_path(modules, path):
 def test_threadpool_limits_by_prefix(openblas_present, mkl_present,
                                      use_infos, prefix):
     original_infos = threadpool_info(return_api=use_infos)
+    print(original_infos)
     original_infos_or_none = original_infos if use_infos else None
 
     mkl_found = any([True for info in original_infos

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -202,7 +202,9 @@ def _set_threadpool_limits(limits, user_api=None, infos=None):
         user_api = [module for module in limits if module in _ALL_USER_APIS]
 
     if infos is not None:
-        modules = infos
+        modules = [
+            module for module in infos
+            if _match_module(module, module['prefix'], prefixes, user_api)]
     else:
         modules = _load_modules(prefixes=prefixes, user_api=user_api)
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -139,7 +139,7 @@ def _get_limit(prefix, user_api, limits):
 
 @_format_docstring(ALL_PREFIXES=_ALL_PREFIXES,
                    INTERNAL_APIS=_ALL_INTERNAL_APIS)
-def _set_threadpool_limits(limits, user_api=None):
+def _set_threadpool_limits(limits, user_api=None, infos=None):
     """Limit the maximal number of threads for threadpools in supported libs
 
     Set the maximal number of threads that can be used in thread pools used in
@@ -201,7 +201,11 @@ def _set_threadpool_limits(limits, user_api=None):
         prefixes = [module for module in limits if module in _ALL_PREFIXES]
         user_api = [module for module in limits if module in _ALL_USER_APIS]
 
-    modules = _load_modules(prefixes=prefixes, user_api=user_api)
+    if infos is not None:
+        modules = infos
+    else:
+        modules = _load_modules(prefixes=prefixes, user_api=user_api)
+
     for module in modules:
         # Workaround clang bug (TODO: report it)
         module['get_num_threads']()
@@ -539,12 +543,12 @@ class threadpool_limits:
     limited. Note that the latter can affect the number of threads used by the
     BLAS libraries if they rely on OpenMP.
     """
-    def __init__(self, limits=None, user_api=None):
+    def __init__(self, limits=None, user_api=None, infos=None):
         self._user_api = _ALL_USER_APIS if user_api is None else [user_api]
 
         if limits is not None:
             self._original_limits = _set_threadpool_limits(
-                limits=limits, user_api=user_api)
+                limits=limits, user_api=user_api, infos=infos)
         else:
             self._original_limits = None
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -203,7 +203,7 @@ def _set_threadpool_limits(limits, user_api=None, infos=None):
 
     if infos is not None:
         modules = [
-            module for module in infos
+            module for module in infos.copy()
             if _match_module(module, module['prefix'], prefixes, user_api)]
     else:
         modules = _load_modules(prefixes=prefixes, user_api=user_api)

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -217,7 +217,7 @@ def _set_threadpool_limits(limits, user_api=None):
 
 
 @_format_docstring(INTERNAL_APIS=_ALL_INTERNAL_APIS)
-def threadpool_info():
+def threadpool_info(return_api=False):
     """Return the maximal number of threads for each detected library.
 
     Return a list with all the supported modules that have been found. Each
@@ -227,6 +227,11 @@ def threadpool_info():
       - 'internal_api': internal API. Possible values are {INTERNAL_APIS}.
       - 'version': version of the library implemented (if available).
       - 'num_threads': the current thread limit.
+
+    If ``return_api``, the dict also contains pointers to the internal API
+    functions:
+      - 'set_num_threads' 
+      - 'get_num_threads' 
     """
     infos = []
     modules = _load_modules(user_api=_ALL_USER_APIS)
@@ -237,9 +242,10 @@ def threadpool_info():
         if module['num_threads'] == -1 and module['internal_api'] == 'blis':
             module['num_threads'] = 1
         # Remove the wrapper for the module and its function
-        del module['set_num_threads'], module['get_num_threads']
         del module['dynlib']
         del module['filename_prefixes']
+        if not return_api:
+            del module['set_num_threads'], module['get_num_threads']
         infos.append(module)
     return infos
 


### PR DESCRIPTION
Use case is the following:
```python
infos = threadpool_info(return_api=True)

# create a python threadpool e.g. with joblib threading backend
joblib.Parallel(backend='threading', n_jobs=88)(
    with threadpool_limits(limit, user_api, infos=infos):
        <some function>
)
```

Proposed api:
- add a parameter to `threadpool_info` to return the `set_num_threads` and `get_num_threads` functions
- add a parameter to `threadpool_limits` to accept already loaded modules instead of finding them again.

todo:
- [ ] lots of tests :)
- [ ] update docstrings