### PR TITLE
[MRG] install llvm-openmp in macOS conda-forge job again

### DIFF
--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -18,7 +18,7 @@ make_conda() {
     if [[ "$UNAMESTR" == "Darwin" ]]; then
         if [[ "$INSTALL_LIBOMP" == "conda-forge" ]]; then
             # Install an OpenMP-enabled clang/llvm from conda-forge
-            TO_INSTALL="$TO_INSTALL conda-forge::compilers"
+            TO_INSTALL="$TO_INSTALL conda-forge::compilers conda-forge::llvm-openmp"
             export CFLAGS="$CFLAGS -I$CONDA/envs/$VIRTUALENV/include"
             export LDFLAGS="$LDFLAGS -Wl,-rpath,$CONDA/envs/$VIRTUALENV/lib -L$CONDA/envs/$VIRTUALENV/lib"
 


### PR DESCRIPTION
Used to be shipped with conda forge compilers. Seems it's not anymore.