### PR TITLE
[MRG] UNIX: dlopen with RTLD_NOLOAD flag

### DIFF
--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -332,15 +332,6 @@ def _match_module(module_info, prefix, prefixes, user_api):
                                    module_info['user_api'] in user_api)
 
 
-def _get_rtld_noload():
-    """Return the RTLD_NOLOAD flags when the OS supports it"""
-    try:
-        rtld_noload = os.RTLD_NOLOAD
-    except AttributeError:
-        rtld_noload = None
-    return rtld_noload
-
-
 def _make_module_info(filepath, module_info, prefix):
     """Make a dict with the information from the module."""
     filepath = os.path.normpath(filepath)

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -328,7 +328,7 @@ def _match_module(module_info, prefix, prefixes, user_api):
 def _make_module_info(filepath, module_info, prefix):
     """Make a dict with the information from the module."""
     filepath = os.path.normpath(filepath)
-    dynlib = ctypes.CDLL(filepath)
+    dynlib = ctypes.CDLL(filepath, mode=os.RTLD_NOLOAD)
     internal_api = module_info['internal_api']
     set_func = getattr(dynlib,
                        _MAP_API_TO_FUNC[internal_api]['set_num_threads'],
@@ -493,7 +493,7 @@ def _get_libc():
         libc_name = find_library("c")
         if libc_name is None:  # pragma: no cover
             return None
-        libc = ctypes.CDLL(libc_name)
+        libc = ctypes.CDLL(libc_name, mode=os.RTLD_NOLOAD)
         _system_libraries["libc"] = libc
     return libc
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -57,6 +57,13 @@ class _dl_phdr_info(ctypes.Structure):
     ]
 
 
+# The RTLD_NOLOAD flag for loading shared libraries is not defined on Windows.
+try:
+        _RTLD_NOLOAD = os.RTLD_NOLOAD
+except AttributeError:
+        _RTLD_NOLOAD = ctypes.DEFAULT_MODE
+
+
 # List of the supported implementations. The items hold the prefix of loaded
 # shared objects, the name of the internal_api to call, matching the
 # MAP_API_TO_FUNC keys and the name of the user_api, in {"blas", "openmp"}.
@@ -325,10 +332,19 @@ def _match_module(module_info, prefix, prefixes, user_api):
                                    module_info['user_api'] in user_api)
 
 
+def _get_rtld_noload():
+    """Return the RTLD_NOLOAD flags when the OS supports it"""
+    try:
+        rtld_noload = os.RTLD_NOLOAD
+    except AttributeError:
+        rtld_noload = None
+    return rtld_noload
+
+
 def _make_module_info(filepath, module_info, prefix):
     """Make a dict with the information from the module."""
     filepath = os.path.normpath(filepath)
-    dynlib = ctypes.CDLL(filepath, mode=os.RTLD_NOLOAD)
+    dynlib = ctypes.CDLL(filepath, mode=_RTLD_NOLOAD)
     internal_api = module_info['internal_api']
     set_func = getattr(dynlib,
                        _MAP_API_TO_FUNC[internal_api]['set_num_threads'],
@@ -493,7 +509,7 @@ def _get_libc():
         libc_name = find_library("c")
         if libc_name is None:  # pragma: no cover
             return None
-        libc = ctypes.CDLL(libc_name, mode=os.RTLD_NOLOAD)
+        libc = ctypes.CDLL(libc_name, mode=_RTLD_NOLOAD)
         _system_libraries["libc"] = libc
     return libc
 


### PR DESCRIPTION
RTLD_NOLOAD is defined in the os module only on unix.
the `mode` parameter is ignored on windows, so it should not matter which value we use for mode. By safety I use the default mode defined by ctypes.

ctypes always add rtld_now, not configurable, to the `mode`. So `mode=RTLD_NOLOAD` should do
`dlopen("path", RTLD_NOW | RTLD_NOLOAD)`.