### PR TITLE
[WIP] ENH: add TBB support

### DIFF
--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -58,6 +58,21 @@ jobs:
         VERSION_PYTHON: '*'
         CC_OUTER_LOOP: 'clang-8'
         CC_INNER_LOOP: 'gcc'
+      # Same but with TBB as threading layer for MKL and tbb4py installed
+      pylatest_conda_mkl_tbb4py_clang_gcc:
+        PACKAGER: 'conda'
+        VERSION_PYTHON: '*'
+        CC_OUTER_LOOP: 'clang-8'
+        CC_INNER_LOOP: 'gcc'
+        MKL_THREADING_LAYER: 'TBB'
+        TBB4PY: 'true'
+      # Same but with TBB as threading layer for MKL and tbb4py not installed
+      pylatest_conda_mkl_tbb_clang_gcc:
+        PACKAGER: 'conda'
+        VERSION_PYTHON: '*'
+        CC_OUTER_LOOP: 'clang-8'
+        CC_INNER_LOOP: 'gcc'
+        MKL_THREADING_LAYER: 'TBB'
       # Same but with numpy / scipy installed with pip from PyPI and switched
       # compilers.
       pylatest_pip_openblas_gcc_clang:

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -45,6 +45,9 @@ if [[ "$PACKAGER" == "conda" ]]; then
             TO_INSTALL="$TO_INSTALL nomkl"
         fi
     fi
+    if [[ ! -z "$TBB4PY" ]]; then
+        TO_INSTALL="$TO_INSTALL tbb4py"
+    fi
 	make_conda $TO_INSTALL
 
 elif [[ "$PACKAGER" == "conda-forge" ]]; then

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -319,8 +319,7 @@ def _get_version(dynlib, internal_api):
     elif internal_api == "blis":
         return _get_blis_version(dynlib)
     elif internal_api == "tbb":
-        # tbb does not expose it's version
-        return None
+        return _get_tbb_version(dynlib)
     else:
         raise NotImplementedError("Unsupported API {}".format(internal_api))
 
@@ -356,6 +355,11 @@ def _get_blis_version(blis_dynlib):
     get_version = getattr(blis_dynlib, "bli_info_get_version_str")
     get_version.restype = ctypes.c_char_p
     return get_version().decode('utf-8')
+
+def _get_tbb_version(tbb_dynlib):
+    """Return the TBB version"""
+    get_version = getattr(tbb_dynlib, "TBB_runtime_interface_version")
+    return str(get_version())
 
 
 def _tbb_get_num_threads():

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -368,16 +368,16 @@ def _make_module_info(filepath, module_info, prefix):
                     tbb.global_control.max_allowed_parallelism)
     else:
         set_func = getattr(dynlib,
-                        _MAP_API_TO_FUNC[internal_api]['set_num_threads'],
-                        lambda num_threads: None)
+                           _MAP_API_TO_FUNC[internal_api]['set_num_threads'],
+                           lambda num_threads: None)
         get_func = getattr(dynlib,
-                        _MAP_API_TO_FUNC[internal_api]['get_num_threads'],
-                        lambda: None)
+                           _MAP_API_TO_FUNC[internal_api]['get_num_threads'],
+                           lambda: None)
 
     module_info = module_info.copy()
     module_info.update(dynlib=dynlib, filepath=filepath, prefix=prefix,
-                    set_num_threads=set_func, get_num_threads=get_func,
-                    version=_get_version(dynlib, internal_api))
+                       set_num_threads=set_func, get_num_threads=get_func,
+                       version=_get_version(dynlib, internal_api))
     return module_info
 
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -362,7 +362,6 @@ def _make_module_info(filepath, module_info, prefix):
             if tbb is not None:
                 tbb.global_control(
                     tbb.global_control.max_allowed_parallelism, max_threads)
-    
         def get_func():
             if tbb is not None:
                 return tbb.global_control.active_value(


### PR DESCRIPTION
fixes #43 

TBB's api can't be accessed with ctypes (c++ class), so we need to access it through tbb4py.

todo:
- [x] decide what to do when tbb4py is not installed but `libtbb` appears in the module infos. 

- [ ] add tests either through mkl threading layer or directly with tbb threadpools.