### PR TITLE
[MRG] Warn when llvm + intel loaded at the same time

### DIFF
--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -77,8 +77,7 @@ stages:
           VERSION_PYTHON: '3.7'
           CC_OUTER_LOOP: 'gcc'
           CC_INNER_LOOP: 'clang-8'
-        # Linux environment with numpy from conda-forge channel and
-        # heterogeneous OpenMP runtimes.
+        # Linux environment with numpy from conda-forge channel
         pylatest_conda_forge:
           PACKAGER: 'conda-forge'
           VERSION_PYTHON: '*'

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -53,16 +53,23 @@ stages:
           BLAS: 'openblas'
           CC_OUTER_LOOP: 'clang-8'
           CC_INNER_LOOP: 'clang-8'
-        # Linux environment with MKL and Clang, known to be unsafe, to test the
-        # warning only.
+        # Linux environment with MKL and Clang (known to be unsafe for
+        # threadpoolctl) to only test the warning from multiple OpenMP.
         pylatest_conda_mkl_clang_gcc:
           PACKAGER: 'conda'
           VERSION_PYTHON: '*'
           BLAS: 'mkl'
           CC_OUTER_LOOP: 'clang-8'
           CC_INNER_LOOP: 'gcc'
-          MKL_THREADING_LAYER: 'INTEL'
           TESTS: 'libomp_libiomp_warning'
+        # Linux environment with MKL, safe for threadpoolctl.
+        pylatest_conda_mkl_gcc_gcc:
+          PACKAGER: 'conda'
+          VERSION_PYTHON: '*'
+          BLAS: 'mkl'
+          CC_OUTER_LOOP: 'gcc'
+          CC_INNER_LOOP: 'gcc'
+          MKL_THREADING_LAYER: 'INTEL'
         # Linux + Python 3.7 with numpy / scipy installed with pip from PyPI
         # and heterogeneous OpenMP runtimes.
         py37_pip_openblas_gcc_clang:

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -53,14 +53,16 @@ stages:
           BLAS: 'openblas'
           CC_OUTER_LOOP: 'clang-8'
           CC_INNER_LOOP: 'clang-8'
-        # Linux environment to test the latest available dependencies and MKL.
-        pylatest_conda_mkl_gcc_gcc:
+        # Linux environment with MKL and Clang, known to be unsafe, to test the
+        # warning only.
+        pylatest_conda_mkl_clang_gcc:
           PACKAGER: 'conda'
           VERSION_PYTHON: '*'
           BLAS: 'mkl'
-          CC_OUTER_LOOP: 'gcc'
+          CC_OUTER_LOOP: 'clang-8'
           CC_INNER_LOOP: 'gcc'
           MKL_THREADING_LAYER: 'INTEL'
+          TESTS: 'libomp_libiomp_warning'
         # Linux + Python 3.7 with numpy / scipy installed with pip from PyPI
         # and heterogeneous OpenMP runtimes.
         py37_pip_openblas_gcc_clang:
@@ -73,7 +75,7 @@ stages:
         pylatest_conda_forge:
           PACKAGER: 'conda-forge'
           VERSION_PYTHON: '*'
-          CC_OUTER_LOOP: 'clang-8'
+          CC_OUTER_LOOP: 'gcc'
           CC_INNER_LOOP: 'gcc'
         # Linux environment with no numpy and heterogeneous OpenMP runtimes.
         pylatest_conda_nonumpy_gcc_clang:

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -54,36 +54,35 @@ stages:
           CC_OUTER_LOOP: 'clang-8'
           CC_INNER_LOOP: 'clang-8'
         # Linux environment to test the latest available dependencies and MKL.
-        # and heterogeneous OpenMP runtime nesting.
-        pylatest_conda_mkl_clang_gcc:
+        pylatest_conda_mkl_gcc_gcc:
           PACKAGER: 'conda'
           VERSION_PYTHON: '*'
           BLAS: 'mkl'
-          CC_OUTER_LOOP: 'clang-8'
+          CC_OUTER_LOOP: 'gcc'
           CC_INNER_LOOP: 'gcc'
           MKL_THREADING_LAYER: 'INTEL'
         # Linux + Python 3.7 with numpy / scipy installed with pip from PyPI
-        # and heterogeneous openmp runtimes.
+        # and heterogeneous OpenMP runtimes.
         py37_pip_openblas_gcc_clang:
           PACKAGER: 'pip'
           VERSION_PYTHON: '3.7'
           CC_OUTER_LOOP: 'gcc'
           CC_INNER_LOOP: 'clang-8'
-        # Linux environment with numpy from conda-forge channel
+        # Linux environment with numpy from conda-forge channel and
+        # heterogeneous OpenMP runtimes.
         pylatest_conda_forge:
           PACKAGER: 'conda-forge'
           VERSION_PYTHON: '*'
-          CC_OUTER_LOOP: 'gcc'
+          CC_OUTER_LOOP: 'clang-8'
           CC_INNER_LOOP: 'gcc'
-        # Linux environment with no numpy and heterogeneous OpenMP runtime
-        # nesting.
+        # Linux environment with no numpy and heterogeneous OpenMP runtimes.
         pylatest_conda_nonumpy_gcc_clang:
           PACKAGER: 'conda'
           NO_NUMPY: 'true'
           VERSION_PYTHON: '*'
           CC_OUTER_LOOP: 'gcc'
           CC_INNER_LOOP: 'clang-8'
-        # Linux environment with numpy linked to BLIS
+        # Linux environment with numpy linked to BLIS.
         pylatest_blis_gcc_clang:
           PACKAGER: 'conda'
           VERSION_PYTHON: '*'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@
   This information is referenced in the `threading_layer` field.
   https://github.com/joblib/threadpoolctl/pull/48
 
+- When threadpoolctl finds libomp (LLVM OpenMP) and libiomp (Intel OpenMP)
+  both loaded, a warning is raised to recall that using threadpoolctl with
+  this mix of OpenMP libraries may cause crashes or deadlocks.
+  https://github.com/joblib/threadpoolctl/pull/49
 
 1.1.0 (2019-09-12)
 ==================

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -14,4 +14,4 @@ fi
 set -x
 PYTHONPATH="." python continuous_integration/display_versions.py
 
-pytest -vlrxXs --junitxml=$JUNITXML --cov=threadpoolctl
+pytest -vlrxXs -k "$TESTS" --junitxml=$JUNITXML --cov=threadpoolctl

--- a/multiple_openmp.md
+++ b/multiple_openmp.md
@@ -2,9 +2,9 @@
 
 OpenMP is an API specification for parallel programming. There are many
 implementations of it, tied to a compiler most of the time: the libgomp library
-for GCC, libomp for Clang, libiomp for ICC and vcomp for MSVC for example. In
-the following, we refer to OpenMP without distinction between the specification
-and an implementation.
+for GCC, libomp for LLVM/Clang, libiomp for ICC and vcomp for MSVC for example.
+In the following, we refer to OpenMP without distinction between the
+specification and an implementation.
 
 In general, it's not advised to have different OpenMP libraries (or even
 different copies of the same library) loaded at the same time in a program.
@@ -24,12 +24,12 @@ program. For instance, on Linux, we never observed any issue between libgomp
 and libiomp, which is the most common mix (numpy with MKL + a package compiled
 with GCC, the most widely used C compiler).
 
-The only unrecoverable incompatibility we encountered is between libomp (Clang)
-and libiomp (ICC), on Linux, manifested by crashes or deadlocks. It can happen
-even with the simplest OpenMP calls like getting the maximum number of threads
-that will be used in a subsequent parallel region. A possible explanation is
-that libomp is actually a fork of libiomp causing name colliding for instance.
-Using threadpoolctl may crash your program in such a setting.
+The only unrecoverable incompatibility we encountered is between libomp
+(LLVM/Clang) and libiomp (ICC), on Linux, manifested by crashes or deadlocks.
+It can happen even with the simplest OpenMP calls like getting the maximum
+number of threads that will be used in a subsequent parallel region. A possible
+explanation is that libomp is actually a fork of libiomp causing name colliding
+for instance. Using threadpoolctl may crash your program in such a setting.
 
 Surprisingly, we never encountered this kind of issue on macOS, where this mix
 is the most frequent (Clang being the default C compiler on macOS).

--- a/multiple_openmp.md
+++ b/multiple_openmp.md
@@ -2,9 +2,9 @@
 
 OpenMP is an API specification for parallel programming. There are many
 implementations of it, tied to a compiler most of the time: the libgomp library
-for GCC, libomp for Clang and libiomp for ICC for example. In the following,
-we refer to OpenMP without distinction between the specification and an
-implementation.
+for GCC, libomp for Clang, libiomp for ICC and vcomp for MSVC for example. In
+the following, we refer to OpenMP without distinction between the specification
+and an implementation.
 
 In general, it's not advised to have different OpenMP libraries (or even
 different copies of the same library) loaded at the same time in a program.
@@ -24,12 +24,12 @@ program. For instance, on Linux, we never observed any issue between libgomp
 and libiomp, which is the most common mix (numpy with MKL + a package compiled
 with GCC, the most widely used C compiler).
 
-The only unrecoverable incompatibility we encountered is between libomp and
-libiomp, on Linux, manifested by crashes or deadlocks. It can happen even with
-the simplest OpenMP calls like getting the maximum number of threads that will
-be used in a subsequent parallel region. An explanation is that libomp is
-actually a fork of libiomp causing name colliding for instance. Using
-threadpoolctl may crash your program in such a setting.
+The only unrecoverable incompatibility we encountered is between libomp (Clang)
+and libiomp (ICC), on Linux, manifested by crashes or deadlocks. It can happen
+even with the simplest OpenMP calls like getting the maximum number of threads
+that will be used in a subsequent parallel region. A possible explanation is
+that libomp is actually a fork of libiomp causing name colliding for instance.
+Using threadpoolctl may crash your program in such a setting.
 
 Surprisingly, we never encountered this kind of issue on macOS, where this mix
 is the most frequent (Clang being the default C compiler on macOS).

--- a/multiple_openmp.md
+++ b/multiple_openmp.md
@@ -33,3 +33,21 @@ for instance. Using threadpoolctl may crash your program in such a setting.
 
 Surprisingly, we never encountered this kind of issue on macOS, where this mix
 is the most frequent (Clang being the default C compiler on macOS).
+
+As far as we know, the only workaround consists in getting rid of one of the
+OpenMP libraries. For example:
+
+- Build your OpenMP-enabled extensions with GCC (or ICC) instead of Clang.
+
+- Install a build of Numpy linked against OpenBLAS instead of MKL. This can be
+  done for instance by installing Numpy from PyPI::
+
+    pip install numpy
+
+  from the conda-forge conda channel::
+
+    conda install -c conda-forge numpy
+
+  or from the default conda channel::
+
+    conda install numpy blas[build=openblas]

--- a/multiple_openmp.md
+++ b/multiple_openmp.md
@@ -1,0 +1,35 @@
+# Multiple OpenMP runtimes
+
+OpenMP is an API specification for parallel programming. There are many
+implementations of it, tied to a compiler most of the time: the libgomp library
+for GCC, libomp for Clang and libiomp for ICC for example. In the following,
+we refer to OpenMP without distinction between the specification and an
+implementation.
+
+In general, it's not advised to have different OpenMP libraries (or even
+different copies of the same library) loaded at the same time in a program.
+It's considered an undefined behavior. Fortunately it's not as bad as it sounds
+in most situations.
+
+However it can easily happen in the Python ecosystem since you can install
+packages compiled with different compilers (hence linked to different OpenMP
+implementations) and import them in a same Python program.
+
+A typical example is installing numpy from Anaconda which ships MKL
+(Intel's math library) and a package using multi-threading with OpenMP
+(Scikit-learn, LightGBM, XGBoost, ...).
+
+From our experience, most OpenMP libraries can seamlessly coexist in a same
+program. For instance, on Linux, we never observed any issue between libgomp
+and libiomp, which is the most common mix (numpy with MKL + a package compiled
+with GCC, the most widely used C compiler).
+
+The only unrecoverable incompatibility we encountered is between libomp and
+libiomp, on Linux, manifested by crashes or deadlocks. It can happen even with
+the simplest OpenMP calls like getting the maximum number of threads that will
+be used in a subsequent parallel region. An explanation is that libomp is
+actually a fork of libiomp causing name colliding for instance. Using
+threadpoolctl may crash your program in such a setting.
+
+Surprisingly, we never encountered this kind of issue on macOS, where this mix
+is the most frequent (Clang being the default C compiler on macOS).

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -377,5 +377,5 @@ def test_libomp_libiomp_warning():
             and sys.platform == "linux"):
         pytest.skip("Requires both libomp and libiomp loaded, on Linux")
 
-    with pytest.warns(RuntimeWarning, match=r"Found intel .* llvm"):
+    with pytest.warns(RuntimeWarning, match=r"Found Intel .* LLVM"):
         _threadpool_info()

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 import pytest
 
 from threadpoolctl import threadpool_limits, threadpool_info, _ThreadpoolInfo
@@ -349,8 +350,9 @@ def test_libomp_libiomp_warning():
     info = _threadpool_info()
     prefixes = [module.prefix for module in info]
 
-    if not ("libomp" in prefixes and "libiomp" in prefixes):
-        pytest.skip("Requires both libomp and libiomp loaded")
+    if not ("libomp" in prefixes and "libiomp" in prefixes
+            and sys.platform == "linux"):
+        pytest.skip("Requires both libomp and libiomp loaded, on Linux")
 
     with pytest.warns(RuntimeWarning, match=r"Found intel .* llvm"):
         _threadpool_info()

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -370,6 +370,9 @@ def test_libomp_libiomp_warning(recwarn):
     # Trigger the import of a potentially clang-compiled extension:
     from ._openmp_test_helper import check_nested_openmp_loops  # noqa
 
+    # Trigger the import of numpy to potentially import Intel OpenMP via MKL
+    import numpy.linalg  # noqa
+
     # Check that a warning is raised when both libomp and libiomp are loaded
     # It should happen in one CI job (pylatest_conda_mkl_clang_gcc).
     info = _threadpool_info()

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -341,3 +341,16 @@ def test_mkl_threading_layer():
 
     actual_layer = mkl_info.modules[0].threading_layer
     assert actual_layer == expected_layer.lower()
+
+
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_libomp_libiomp_warning():
+    # Check that a warning is raised when both libomp and libiomp are loaded
+    info = _threadpool_info()
+    prefixes = [module.prefix for module in info]
+
+    if not ("libomp" in prefixes and "libiomp" in prefixes):
+        pytest.skip("Requires both libomp and libiomp loaded")
+
+    with pytest.warns(RuntimeWarning, match=r"Found intel .* llvm"):
+        _threadpool_info()

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -534,8 +534,10 @@ class _ThreadpoolInfo():
         prefixes = [module.prefix for module in self.modules]
         msg = textwrap.dedent(
             """
-            Found intel OpenMP ('libiomp') and llvm OpenMP ('libomp') loaded at
-            the same time. Both libraries are known to be incompatible.
+            Found Intel OpenMP ('libiomp') and LLVM OpenMP ('libomp') loaded at
+            the same time. Both libraries are known to be incompatible and this
+            can cause random crashes or deadlocks on Linux when loaded in the
+            same Python program.
             Using threadpoolctl may cause crashes or deadlocks. For more
             information and possible workarounds, please see
                 https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -538,7 +538,7 @@ class _ThreadpoolInfo():
             the same time. Both libraries are known to be incompatible.
             Using threadpoolctl may cause crashes or deadlocks. For more
             information and possible workarounds, please see
-                https://github.com/joblib/threadpoolctl/blob/master/TODO.md
+                https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md
             """)
         if 'libomp' in prefixes and 'libiomp' in prefixes:
             warnings.warn(msg, RuntimeWarning)


### PR DESCRIPTION
Following the discussion in #40 and in particular [https://github.com/joblib/threadpoolctl/issues/40#issuecomment-545377697](https://github.com/joblib/threadpoolctl/issues/40#issuecomment-545377697)

both implementations of OpenMP are actually the same and are incompatible in the sense that they do not accept having multiple copies at the same time. See this error message from llvm
``OMP: Hint This means that multiple copies of the OpenMP runtime have been linked into the program.``

(un)fortunately crashes should not occur very often outside of threadpoolctl since we are only able to create them by accessing the openmp api (get/set num threads, ...), not by mixing pranges and blas calls.

This PR adds the emission of a warning when trying to access threadpoolctl functionalities.

TODO:
 - [x] Add a page documenting all our discoveries about that and possible workarounds, and point the warning to that page

 - [x] test on macOS, especially the switch of threading layer for mkl

 - [x] add a test for the warning

 - [x] warn also in threadpool_limits

 - [x] What to do with all our clang ci jobs ?