### PR TITLE
[MRG] CI: Pin Python version when installing with pip

### DIFF
--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -59,11 +59,11 @@ jobs:
         VERSION_PYTHON: '*'
         CC_OUTER_LOOP: 'clang-8'
         CC_INNER_LOOP: 'gcc'
-      # Same but with numpy / scipy installed with pip from PyPI and switched
-      # compilers.
-      pylatest_pip_openblas_gcc_clang:
+      # Linux + Python 3.7 with numpy / scipy installed with pip from PyPI and
+      # heterogeneous openmp runtimes.
+      py37_pip_openblas_gcc_clang:
         PACKAGER: 'pip'
-        VERSION_PYTHON: '*'
+        VERSION_PYTHON: '3.7'
         CC_OUTER_LOOP: 'gcc'
         CC_INNER_LOOP: 'clang-8'
       # Linux environment with numpy from conda-forge channel


### PR DESCRIPTION
When installing packages with pip we can't install the latest Python version because wheels may not yet be available. It's the case right now for scipy and Python 3.8.