### PR TITLE
CI Fix missing apt-get update on azure

### DIFF
--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -66,6 +66,7 @@ elif [[ "$PACKAGER" == "ubuntu" ]]; then
     # Remove the ubuntu toolchain PPA that seems to be invalid:
     # https://github.com/scikit-learn/scikit-learn/pull/13934
     sudo add-apt-repository --remove ppa:ubuntu-toolchain-r/test
+    sudo apt-get update
     sudo apt-get install python3-scipy python3-virtualenv $APT_BLAS
     python3 -m virtualenv --system-site-packages --python=python3 $VIRTUALENV
     source $VIRTUALENV/bin/activate


### PR DESCRIPTION
CI is broken because we need to update apt-get. We did the same in scikit-learn ([see](https://github.com/scikit-learn/scikit-learn/pull/15563)).