### PR TITLE
[MRG] MNT CI Make pytest ignore _openmp_test_helper when discovering tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,1 @@
+collect_ignore = ["tests/_openmp_test_helper"]

--- a/continuous_integration/posix.yml
+++ b/continuous_integration/posix.yml
@@ -15,9 +15,6 @@ jobs:
     - script: |
         pip3 install flake8
         python3 -m flake8 .
-        cython --version
-        which cython
-        which pytest
       displayName: Lint
       condition: eq(variables['LINT'], 'true')
     - bash: echo "##vso[task.prependpath]$CONDA/bin"

--- a/continuous_integration/posix.yml
+++ b/continuous_integration/posix.yml
@@ -15,6 +15,9 @@ jobs:
     - script: |
         pip3 install flake8
         python3 -m flake8 .
+        cython --version
+        which cython
+        which pytest
       displayName: Lint
       condition: eq(variables['LINT'], 'true')
     - bash: echo "##vso[task.prependpath]$CONDA/bin"


### PR DESCRIPTION
The last version of pytest (5.2.3) released yesterday makes ci fails due to an error when discovering tests.

In the job where we don't have numpy, some cython extensions are not compiled which errors when importing them in `_openmp_test_helper/__init__.py`. I don't know why we did not have that issue with previous pytest versions...