### PR TITLE
[MRG] MNT use new syntax to select blas with conda

### DIFF
--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -18,12 +18,15 @@ stages:
         pylatest_conda:
           VERSION_PYTHON: '*'
           PACKAGER: 'conda'
+          BLAS: 'mkl'
         py36_conda:
           VERSION_PYTHON: '3.6'
           PACKAGER: 'conda'
+          BLAS: 'openblas'
         py35_pip:
           VERSION_PYTHON: '3.5'
           PACKAGER: 'pip'
+          BLAS: 'mkl'
 
 
   - template: continuous_integration/posix.yml
@@ -115,9 +118,9 @@ stages:
       vmImage: xcode9-macos10.13
       matrix:
         # MacOS environment with OpenMP installed through homebrew
-        pylatest_conda_homebrew_libomp:
+        py35_conda_homebrew_libomp:
           PACKAGER: 'conda'
-          VERSION_PYTHON: '*'
+          VERSION_PYTHON: '3.5'
           BLAS: 'mkl'
           CC_OUTER_LOOP: 'clang'
           CC_INNER_LOOP: 'clang'

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -15,8 +15,8 @@ stages:
       name: Windows
       vmImage: vs2017-win2016
       matrix:
-        py37_conda:
-          VERSION_PYTHON: '3.7'
+        pylatest_conda:
+          VERSION_PYTHON: '*'
           PACKAGER: 'conda'
         py36_conda:
           VERSION_PYTHON: '3.6'
@@ -118,6 +118,7 @@ stages:
         pylatest_conda_homebrew_libomp:
           PACKAGER: 'conda'
           VERSION_PYTHON: '*'
+          BLAS: 'mkl'
           CC_OUTER_LOOP: 'clang'
           CC_INNER_LOOP: 'clang'
           INSTALL_LIBOMP: 'homebrew'
@@ -125,6 +126,7 @@ stages:
         pylatest_conda_conda_forge_clang:
           PACKAGER: 'conda'
           VERSION_PYTHON: '*'
+          BLAS: 'mkl'
           CC_OUTER_LOOP: 'clang'
           CC_INNER_LOOP: 'clang'
           INSTALL_LIBOMP: 'conda-forge'

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -50,7 +50,7 @@ stages:
         py36_conda_openblas_clang_clang:
           PACKAGER: 'conda'
           VERSION_PYTHON: '3.6'
-          NO_MKL: 'true'
+          BLAS: 'openblas'
           CC_OUTER_LOOP: 'clang-8'
           CC_INNER_LOOP: 'clang-8'
         # Linux environment to test the latest available dependencies and MKL.
@@ -58,11 +58,12 @@ stages:
         pylatest_conda_mkl_clang_gcc:
           PACKAGER: 'conda'
           VERSION_PYTHON: '*'
+          BLAS: 'mkl'
           CC_OUTER_LOOP: 'clang-8'
           CC_INNER_LOOP: 'gcc'
           MKL_THREADING_LAYER: 'INTEL'
-        # Linux + Python 3.7 with numpy / scipy installed with pip from PyPI and
-        # heterogeneous openmp runtimes.
+        # Linux + Python 3.7 with numpy / scipy installed with pip from PyPI
+        # and heterogeneous openmp runtimes.
         py37_pip_openblas_gcc_clang:
           PACKAGER: 'pip'
           VERSION_PYTHON: '3.7'

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -18,15 +18,12 @@ stages:
         pylatest_conda:
           VERSION_PYTHON: '*'
           PACKAGER: 'conda'
-          BLAS: 'mkl'
         py36_conda:
           VERSION_PYTHON: '3.6'
           PACKAGER: 'conda'
-          BLAS: 'openblas'
         py35_pip:
           VERSION_PYTHON: '3.5'
           PACKAGER: 'pip'
-          BLAS: 'mkl'
 
 
   - template: continuous_integration/posix.yml

--- a/continuous_integration/install.cmd
+++ b/continuous_integration/install.cmd
@@ -18,7 +18,7 @@ python --version
 pip --version
 
 @rem Install dependencies with either conda or pip.
-if "%PACKAGER%" == "conda" (%CONDA_INSTALL% numpy=1.15 scipy pytest cython blas[build=%BLAS%])
+if "%PACKAGER%" == "conda" (%CONDA_INSTALL% numpy scipy pytest cython)
 if "%PACKAGER%" == "pip" (%PIP_INSTALL% numpy scipy pytest cython)
 
 @rem Install extra developer dependencies

--- a/continuous_integration/install.cmd
+++ b/continuous_integration/install.cmd
@@ -18,7 +18,7 @@ python --version
 pip --version
 
 @rem Install dependencies with either conda or pip.
-if "%PACKAGER%" == "conda" (%CONDA_INSTALL% numpy=1.15 scipy pytest cython)
+if "%PACKAGER%" == "conda" (%CONDA_INSTALL% numpy=1.15 scipy pytest cython blas[build=%BLAS%])
 if "%PACKAGER%" == "pip" (%PIP_INSTALL% numpy scipy pytest cython)
 
 @rem Install extra developer dependencies

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -40,7 +40,7 @@ make_conda() {
 if [[ "$PACKAGER" == "conda" ]]; then
     TO_INSTALL="python=$VERSION_PYTHON pip"
     if [[ "$NO_NUMPY" != "true" ]]; then
-        TO_INSTALL="$TO_INSTALL numpy scipy blas[$BLAS]"
+        TO_INSTALL="$TO_INSTALL numpy scipy blas[build=$BLAS]"
     fi
 	make_conda $TO_INSTALL
 

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -40,10 +40,7 @@ make_conda() {
 if [[ "$PACKAGER" == "conda" ]]; then
     TO_INSTALL="python=$VERSION_PYTHON pip"
     if [[ "$NO_NUMPY" != "true" ]]; then
-        TO_INSTALL="$TO_INSTALL numpy scipy"
-        if [[ "$NO_MKL" == "true" ]]; then
-            TO_INSTALL="$TO_INSTALL nomkl"
-        fi
+        TO_INSTALL="$TO_INSTALL numpy scipy blas[$BLAS]"
     fi
 	make_conda $TO_INSTALL
 


### PR DESCRIPTION
conda install numpy is less predictable than it used to be w.r.t blas.
in python < 3.8 it will install mkl; in python 3.8 it's openblas (for now ?)

We can be sure of which implem of blas we will get with the following syntax
`conda install numpy blas[build=mkl]`

An alternative syntax is `blas=*=mkl` but I prefer the first one.

@ogrisel Fixes the first part of the issue in #55