### PR TITLE
[MRG] MNT Fix meta-test distinguish skipped from other records

### DIFF
--- a/continuous_integration/check_no_test_skipped.py
+++ b/continuous_integration/check_no_test_skipped.py
@@ -24,16 +24,13 @@ for name in os.listdir(base_dir):
         # All tests are identified by the xml tag testcase.
         for test in root.iter("testcase"):
             test_name = test.attrib["name"]
-            if test_name not in always_skipped:
-                always_skipped[test_name] = True
-
-            for child in test:
-                if child.tag == "skipped":
-                    print("    -", test_name)
-                    always_skipped[test_name] &= True
-                    break
+            skipped = any(child.tag == "skipped" for child in test)
+            if skipped:
+                print("    -", test_name)
+            if test_name in always_skipped:
+                always_skipped[test_name] &= skipped
             else:
-                always_skipped[test_name] = False
+                always_skipped[test_name] = skipped
 
 print("\n------------------------------------------------------------------\n")
 fail = False

--- a/continuous_integration/check_no_test_skipped.py
+++ b/continuous_integration/check_no_test_skipped.py
@@ -16,18 +16,25 @@ aggregated_results = {}
 for name in os.listdir(base_dir):
     # all test result files are in /base_dir/jobs.*/ dirs
     if name.startswith("stage1."):
+        print("> processing test result from job", name.replace("stage1", ""))
         result_file = os.path.join(base_dir, name, "test-data.xml")
         root = ET.parse(result_file).getroot()
 
         # All tests are identified by the xml tag testcase.
-        for test in root.iter('testcase'):
-            test_name = test.attrib['name']
+        for test in root.iter("testcase"):
+            test_name = test.attrib["name"]
             if test_name not in aggregated_results:
-                # len(test) is > 0 if the test is skipped.
-                aggregated_results[test_name] = not bool(len(test))
-            else:
-                aggregated_results[test_name] |= not bool(len(test))
+                aggregated_results[test_name] = False
+            print("  -", test_name)
 
+            for child in test:
+                print("    -", child.tag)
+                if child.tag == "skipped":
+                    aggregated_results[test_name] |= False
+            else:
+                aggregated_results[test_name] |= True
+
+print("\n------------------------------------------------------------------\n")
 fail = False
 for test, result in aggregated_results.items():
     if not result:

--- a/continuous_integration/check_no_test_skipped.py
+++ b/continuous_integration/check_no_test_skipped.py
@@ -31,6 +31,7 @@ for name in os.listdir(base_dir):
                 print("    -", child.tag)
                 if child.tag == "skipped":
                     aggregated_results[test_name] |= False
+                    break
             else:
                 aggregated_results[test_name] |= True
 

--- a/continuous_integration/check_no_test_skipped.py
+++ b/continuous_integration/check_no_test_skipped.py
@@ -29,7 +29,7 @@ for name in os.listdir(base_dir):
 
             for child in test:
                 if child.tag == "skipped":
-                    print("  -", test_name)
+                    print("    -", test_name)
                     always_skipped[test_name] |= True
                     break
             else:

--- a/continuous_integration/check_no_test_skipped.py
+++ b/continuous_integration/check_no_test_skipped.py
@@ -25,12 +25,12 @@ for name in os.listdir(base_dir):
         for test in root.iter("testcase"):
             test_name = test.attrib["name"]
             if test_name not in always_skipped:
-                always_skipped[test_name] = False
+                always_skipped[test_name] = True
 
             for child in test:
                 if child.tag == "skipped":
                     print("    -", test_name)
-                    always_skipped[test_name] |= True
+                    always_skipped[test_name] &= True
                     break
             else:
                 always_skipped[test_name] = False

--- a/continuous_integration/check_no_test_skipped.py
+++ b/continuous_integration/check_no_test_skipped.py
@@ -11,34 +11,34 @@ base_dir = sys.argv[1]
 
 # dict {test: result} where result is False if the test was skipped in every
 # job and True otherwise.
-aggregated_results = {}
+always_skipped = {}
 
 for name in os.listdir(base_dir):
     # all test result files are in /base_dir/jobs.*/ dirs
     if name.startswith("stage1."):
         print("> processing test result from job", name.replace("stage1", ""))
+        print("  > tests skipped:")
         result_file = os.path.join(base_dir, name, "test-data.xml")
         root = ET.parse(result_file).getroot()
 
         # All tests are identified by the xml tag testcase.
         for test in root.iter("testcase"):
             test_name = test.attrib["name"]
-            if test_name not in aggregated_results:
-                aggregated_results[test_name] = False
-            print("  -", test_name)
+            if test_name not in always_skipped:
+                always_skipped[test_name] = False
 
             for child in test:
-                print("    -", child.tag)
                 if child.tag == "skipped":
-                    aggregated_results[test_name] |= False
+                    print("  -", test_name)
+                    always_skipped[test_name] |= True
                     break
             else:
-                aggregated_results[test_name] |= True
+                always_skipped[test_name] = False
 
 print("\n------------------------------------------------------------------\n")
 fail = False
-for test, result in aggregated_results.items():
-    if not result:
+for test, skipped in always_skipped.items():
+    if skipped:
         fail = True
         print(test, "was skipped in every job")
 


### PR DESCRIPTION
Actually check that the test is skipped.
Before that, a false positive could be due to a warning raised in a test for instance.

Also made the meta test way more verbose