### PR TITLE
[MRG] ENH add threading layer for BLIS and OpenBLAS

### DIFF
--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -84,7 +84,7 @@ stages:
           CC_OUTER_LOOP: 'gcc'
           CC_INNER_LOOP: 'clang-8'
         # Linux environment with numpy linked to BLIS
-        pylatest_blis_gcc_clang:
+        pylatest_blis_gcc_clang_openmp:
           PACKAGER: 'conda'
           VERSION_PYTHON: '*'
           INSTALL_BLIS: 'true'
@@ -92,7 +92,8 @@ stages:
           CC_OUTER_LOOP: 'gcc'
           CC_INNER_LOOP: 'gcc'
           BLIS_CC: 'clang-8'
-        pylatest_blis_clang_gcc:
+          BLIS_ENABLE_THREADING: 'openmp'
+        pylatest_blis_clang_gcc_pthreads:
           PACKAGER: 'conda'
           VERSION_PYTHON: '*'
           INSTALL_BLIS: 'true'
@@ -100,6 +101,7 @@ stages:
           CC_OUTER_LOOP: 'clang-8'
           CC_INNER_LOOP: 'clang-8'
           BLIS_CC: 'gcc-8'
+          BLIS_ENABLE_THREADING: 'pthreads'
         pylatest_blis_no_threading:
           PACKAGER: 'conda'
           VERSION_PYTHON: '*'
@@ -108,6 +110,7 @@ stages:
           CC_OUTER_LOOP: 'gcc'
           CC_INNER_LOOP: 'gcc'
           BLIS_CC: 'gcc-8'
+          BLIS_ENABLE_THREADING: 'no'
 
   - template: continuous_integration/posix.yml
     parameters:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,11 @@
-1.2.0 (TBD)
+2.0.0 (TBD)
 ===========
 
-- Expose MKL threading layer in informations displayed by `threadpool_info`.
-  This information is referenced in the `threading_layer` field.
+- Expose MKL, BLIS and OpenBLAS threading layer in informations displayed by
+  `threadpool_info`. This information is referenced in the `threading_layer`
+  field.
   https://github.com/joblib/threadpoolctl/pull/48
+  https://github.com/joblib/threadpoolctl/pull/60
 
 
 1.1.0 (2019-09-12)

--- a/continuous_integration/install_with_blis.sh
+++ b/continuous_integration/install_with_blis.sh
@@ -27,12 +27,8 @@ pushd ..
 mkdir BLIS_install
 git clone https://github.com/flame/blis.git
 pushd blis
-if [[ "$BLIS_NUM_THREADS" == "1" ]]; then
-    THREADING='no'
-else
-    THREADING='openmp'
-fi
-./configure --prefix=$ABS_PATH/BLIS_install --enable-cblas --enable-threading=$THREADING CC=$BLIS_CC auto
+
+./configure --prefix=$ABS_PATH/BLIS_install --enable-cblas --enable-threading=$BLIS_ENABLE_THREADING CC=$BLIS_CC auto
 make -j4
 make install
 popd

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -341,3 +341,19 @@ def test_mkl_threading_layer():
 
     actual_layer = mkl_info.modules[0].threading_layer
     assert actual_layer == expected_layer.lower()
+
+
+def test_blis_threading_layer():
+    # Check that threadpool_info correctly recovers the threading layer used
+    # by blis
+    blis_info = _threadpool_info().get_modules("internal_api", "blis")
+    expected_layer = os.getenv("BLIS_ENABLE_THREADING")
+    if expected_layer == "no":
+        expected_layer = "disabled"
+
+    if not (blis_info and expected_layer):
+        pytest.skip("requires BLIS and the environment variable "
+                    "BLIS_ENABLE_THREADING set")
+
+    actual_layer = blis_info.modules[0].threading_layer
+    assert actual_layer == expected_layer

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -54,8 +54,10 @@ def test_ThreadpoolInfo_todicts():
         assert "version" in module_dict
         assert "num_threads" in module_dict
 
-        if module.internal_api in ("mkl", "blis", "openblas"):
+        if module.internal_api == "mkl":
             assert "threading_layer" in module_dict
+        if module.internal_api in ("blis", "openblas"):
+            assert "multithreading" in module_dict
 
 
 @pytest.mark.parametrize("prefix", _ALL_PREFIXES)

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -54,7 +54,7 @@ def test_ThreadpoolInfo_todicts():
         assert "version" in module_dict
         assert "num_threads" in module_dict
 
-        if module.internal_api in ("mkl", "blis"):
+        if module.internal_api in ("mkl", "blis", "openblas"):
             assert "threading_layer" in module_dict
 
 

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -54,10 +54,8 @@ def test_ThreadpoolInfo_todicts():
         assert "version" in module_dict
         assert "num_threads" in module_dict
 
-        if module.internal_api == "mkl":
+        if module.internal_api in ("mkl", "blis", "openblas"):
             assert "threading_layer" in module_dict
-        if module.internal_api in ("blis", "openblas"):
-            assert "multithreading" in module_dict
 
 
 @pytest.mark.parametrize("prefix", _ALL_PREFIXES)

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -54,7 +54,7 @@ def test_ThreadpoolInfo_todicts():
         assert "version" in module_dict
         assert "num_threads" in module_dict
 
-        if module.internal_api == "mkl":
+        if module.internal_api in ("mkl", "blis"):
             assert "threading_layer" in module_dict
 
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -637,14 +637,14 @@ class _OpenBLASModule(_Module):
         return set_func(num_threads)
 
     def _get_extra_info(self):
-        self.threading_layer = self.get_threading_layer()
+        self.multithreading = self.get_multithreading()
 
     def get_threading_layer(self):
         """Return the threading layer of OpenBLAS"""
-        threading_layer = self._dynlib.openblas_get_parallel()
-        if threading_layer == 2:
+        multithreading = self._dynlib.openblas_get_parallel()
+        if multithreading == 2:
             return "openmp"
-        elif threading_layer == 1:
+        elif multithreading == 1:
             return "pthreads"
         return "disabled"
 
@@ -671,9 +671,9 @@ class _BLISModule(_Module):
         return set_func(num_threads)
 
     def _get_extra_info(self):
-        self.threading_layer = self.get_threading_layer()
+        self.multithreading = self.get_multithreading()
 
-    def get_threading_layer(self):
+    def get_multithreading(self):
         """Return the threading layer of BLIS"""
         if self._dynlib.bli_info_get_enable_openmp():
             return "openmp"

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -662,7 +662,15 @@ class _BLISModule(_Module):
         return set_func(num_threads)
 
     def _get_extra_info(self):
-        pass
+        self.threading_layer = self.get_threading_layer()
+
+    def get_threading_layer(self):
+        """Return the threading layer of BLIS"""
+        if self._dynlib.bli_info_get_enable_openmp():
+            return "openmp"
+        elif self._dynlib.bli_info_get_enable_pthreads():
+            return "pthreads"
+        return "disabled"
 
 
 class _MKLModule(_Module):

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -639,8 +639,8 @@ class _OpenBLASModule(_Module):
     def _get_extra_info(self):
         self.multithreading = self.get_multithreading()
 
-    def get_threading_layer(self):
-        """Return the threading layer of OpenBLAS"""
+    def get_multithreading(self):
+        """Return the multithreading option of OpenBLAS"""
         multithreading = self._dynlib.openblas_get_parallel()
         if multithreading == 2:
             return "openmp"
@@ -674,7 +674,7 @@ class _BLISModule(_Module):
         self.multithreading = self.get_multithreading()
 
     def get_multithreading(self):
-        """Return the threading layer of BLIS"""
+        """Return the multithreading option of BLIS"""
         if self._dynlib.bli_info_get_enable_openmp():
             return "openmp"
         elif self._dynlib.bli_info_get_enable_pthreads():

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -637,14 +637,14 @@ class _OpenBLASModule(_Module):
         return set_func(num_threads)
 
     def _get_extra_info(self):
-        self.multithreading = self.get_multithreading()
+        self.threading_layer = self.get_threading_layer()
 
-    def get_multithreading(self):
-        """Return the multithreading option of OpenBLAS"""
-        multithreading = self._dynlib.openblas_get_parallel()
-        if multithreading == 2:
+    def get_threading_layer(self):
+        """Return the threading layer of OpenBLAS"""
+        threading_layer = self._dynlib.openblas_get_parallel()
+        if threading_layer == 2:
             return "openmp"
-        elif multithreading == 1:
+        elif threading_layer == 1:
             return "pthreads"
         return "disabled"
 
@@ -671,10 +671,10 @@ class _BLISModule(_Module):
         return set_func(num_threads)
 
     def _get_extra_info(self):
-        self.multithreading = self.get_multithreading()
+        self.threading_layer = self.get_threading_layer()
 
-    def get_multithreading(self):
-        """Return the multithreading option of BLIS"""
+    def get_threading_layer(self):
+        """Return the threading layer of BLIS"""
         if self._dynlib.bli_info_get_enable_openmp():
             return "openmp"
         elif self._dynlib.bli_info_get_enable_pthreads():

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -637,7 +637,16 @@ class _OpenBLASModule(_Module):
         return set_func(num_threads)
 
     def _get_extra_info(self):
-        pass
+        self.threading_layer = self.get_threading_layer()
+
+    def get_threading_layer(self):
+        """Return the threading layer of OpenBLAS"""
+        threading_layer = self._dynlib.openblas_get_parallel()
+        if threading_layer == 2:
+            return "openmp"
+        elif threading_layer == 1:
+            return "pthreads"
+        return "disabled"
 
 
 class _BLISModule(_Module):


### PR DESCRIPTION
Show information about how BLIS and OpenBLAS were built. Both can be built with multithreading disabled, multithreading with pthreads or multithreading with OpenMP.

I'm not sure about the name, because it's not exactly the same kind as mkl's threading layer. Maybe "multithreading" = {"disabled", "pthreads", "openmp"} would be better. What do you think ?