### PR TITLE
[MRG] MNT CI Turn Warnings into Errors

### DIFF
--- a/continuous_integration/test_script.cmd
+++ b/continuous_integration/test_script.cmd
@@ -1,3 +1,5 @@
 call activate %VIRTUALENV%
 
+python continuous_integration/display_versions.py
+
 pytest -vlrxXs --junitxml=%JUNITXML% --cov=threadpoolctl

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -14,4 +14,4 @@ fi
 set -x
 PYTHONPATH="." python continuous_integration/display_versions.py
 
-pytest -vlrxXs --junitxml=$JUNITXML --cov=threadpoolctl
+pytest -vlrxXs -W error --junitxml=$JUNITXML --cov=threadpoolctl

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -302,8 +302,10 @@ def test_nested_prange_blas(nthreads_outer):
     assert original_info == _threadpool_info()
 
 
-# the method `get_original_num_threads` raises a UserWarning in one CI job. It
-# is expected so we can safely filter it.
+# the method `get_original_num_threads` raises a UserWarning due to different
+# num_threads from libraries with the same `user_api`. It will be raised only
+# in the CI job with 2 openblas (py37_pip_openblas_gcc_clang). It is expected
+# so we can safely filter it.
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("limit", [1, None])
 def test_get_original_num_threads(limit):

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -302,6 +302,8 @@ def test_nested_prange_blas(nthreads_outer):
     assert original_info == _threadpool_info()
 
 
+# the method `get_original_num_threads` raises a UserWarning in one CI job. It
+# is expected so we can safely filter it.
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("limit", [1, None])
 def test_get_original_num_threads(limit):

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -302,6 +302,7 @@ def test_nested_prange_blas(nthreads_outer):
     assert original_info == _threadpool_info()
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("limit", [1, None])
 def test_get_original_num_threads(limit):
     # Tests the method get_original_num_threads of the context manager
@@ -313,7 +314,6 @@ def test_get_original_num_threads(limit):
         original_info = _threadpool_info()
         with threadpool_limits(limits=limit, user_api="blas") as threadpoolctx:
             original_num_threads = threadpoolctx.get_original_num_threads()
-            print(original_num_threads)
 
             assert "openmp" not in original_num_threads
 


### PR DESCRIPTION
- turn all warnings into errors in CI
- filter the warning from `get_original_num_threads`
- clean up a print in the tests which should not be there
- display the versions and threadpool_info before the tests on windows as it's already done on linux