### PR TITLE
FIX use more reliable naming syntax for MKL version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@
   (`openblas_get_corename`) in `threadpool_info()` and BLIS
   (`bli_arch_query_id` and `bli_arch_string`).
 
+- Fixed a bug when the version of MKL was not found. The
+  "version" field is now set to None in that case.
+  https://github.com/joblib/threadpoolctl/pull/82
+
 2.1.0 (2020-05-29)
 ==================
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -708,7 +708,7 @@ class _MKLModule(_Module):
     """Module class for MKL"""
     def get_version(self):
         res = ctypes.create_string_buffer(200)
-        self._dynlib.mkl_get_version_string(res, 200)
+        self._dynlib.MKL_Get_Version_String(res, 200)
 
         version = res.value.decode("utf-8")
         group = re.search(r"Version ([^ ]+) ", version)

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -707,6 +707,9 @@ class _BLISModule(_Module):
 class _MKLModule(_Module):
     """Module class for MKL"""
     def get_version(self):
+        if not hasattr(self._dynlib, "MKL_Get_Version_String"):
+            return None
+
         res = ctypes.create_string_buffer(200)
         self._dynlib.MKL_Get_Version_String(res, 200)
 


### PR DESCRIPTION
Fixes #81 

It seems that the naming syntax `MKL_My_Function` is safer to use than `mkl_my_function` which may not exist. We already observed that (for windows for instance iirc), this is why we already use the first syntax everywhere. I should have done that for the version as well in the first place.

Let's wait confirmation from the discussion in #81 before merging.