### PR TITLE
[MRG] Fix compilation with clang and flake8 install in CI

### DIFF
--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -51,15 +51,15 @@ stages:
           PACKAGER: 'conda'
           VERSION_PYTHON: '3.6'
           BLAS: 'openblas'
-          CC_OUTER_LOOP: 'clang-8'
-          CC_INNER_LOOP: 'clang-8'
+          CC_OUTER_LOOP: 'clang-10'
+          CC_INNER_LOOP: 'clang-10'
         # Linux environment with MKL and Clang (known to be unsafe for
         # threadpoolctl) to only test the warning from multiple OpenMP.
         pylatest_conda_mkl_clang_gcc:
           PACKAGER: 'conda'
           VERSION_PYTHON: '*'
           BLAS: 'mkl'
-          CC_OUTER_LOOP: 'clang-8'
+          CC_OUTER_LOOP: 'clang-10'
           CC_INNER_LOOP: 'gcc'
           TESTS: 'libomp_libiomp_warning'
         # Linux environment with MKL, safe for threadpoolctl.
@@ -76,7 +76,7 @@ stages:
           PACKAGER: 'pip'
           VERSION_PYTHON: '3.7'
           CC_OUTER_LOOP: 'gcc'
-          CC_INNER_LOOP: 'clang-8'
+          CC_INNER_LOOP: 'clang-10'
         # Linux environment with numpy from conda-forge channel
         pylatest_conda_forge:
           PACKAGER: 'conda-forge'
@@ -89,7 +89,7 @@ stages:
           NO_NUMPY: 'true'
           VERSION_PYTHON: '*'
           CC_OUTER_LOOP: 'gcc'
-          CC_INNER_LOOP: 'clang-8'
+          CC_INNER_LOOP: 'clang-10'
         # Linux environment with numpy linked to BLIS
         pylatest_blis_gcc_clang_openmp:
           PACKAGER: 'conda'
@@ -98,15 +98,15 @@ stages:
           BLIS_NUM_THREADS: '4'
           CC_OUTER_LOOP: 'gcc'
           CC_INNER_LOOP: 'gcc'
-          BLIS_CC: 'clang-8'
+          BLIS_CC: 'clang-10'
           BLIS_ENABLE_THREADING: 'openmp'
         pylatest_blis_clang_gcc_pthreads:
           PACKAGER: 'conda'
           VERSION_PYTHON: '*'
           INSTALL_BLIS: 'true'
           BLIS_NUM_THREADS: '4'
-          CC_OUTER_LOOP: 'clang-8'
-          CC_INNER_LOOP: 'clang-8'
+          CC_OUTER_LOOP: 'clang-10'
+          CC_INNER_LOOP: 'clang-10'
           BLIS_CC: 'gcc-8'
           BLIS_ENABLE_THREADING: 'pthreads'
         pylatest_blis_no_threading:

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -4,13 +4,13 @@ set -e
 
 UNAMESTR=`uname`
 
-if [[ "$CC_OUTER_LOOP" == "clang-8" || "$CC_INNER_LOOP" == "clang-8" ]]; then
+if [[ "$CC_OUTER_LOOP" == "clang-10" || "$CC_INNER_LOOP" == "clang-10" ]]; then
     # Assume Ubuntu: install a recent version of clang and libomp
-    echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
-    echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+    # echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
+    # echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
+    # wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
     sudo apt update
-    sudo apt install clang-8 libomp-8-dev
+    sudo apt install clang-10 # libomp-8-dev
 fi
 
 make_conda() {

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -6,9 +6,6 @@ UNAMESTR=`uname`
 
 if [[ "$CC_OUTER_LOOP" == "clang-10" || "$CC_INNER_LOOP" == "clang-10" ]]; then
     # Assume Ubuntu: install a recent version of clang and libomp
-    # echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
-    # echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
-    # wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
     wget https://apt.llvm.org/llvm.sh
     chmod +x llvm.sh
     sudo ./llvm.sh 10

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -9,8 +9,9 @@ if [[ "$CC_OUTER_LOOP" == "clang-10" || "$CC_INNER_LOOP" == "clang-10" ]]; then
     # echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
     # echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
     # wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-    sudo apt update
-    sudo apt install clang-10 # libomp-8-dev
+    wget https://apt.llvm.org/llvm.sh
+    chmod +x llvm.sh
+    sudo ./llvm.sh 10
 fi
 
 make_conda() {

--- a/continuous_integration/install_with_blis.sh
+++ b/continuous_integration/install_with_blis.sh
@@ -10,8 +10,9 @@ popd
 # echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
 # echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
 # wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-sudo apt update
-sudo apt install clang-10 #libomp-8-dev
+wget https://apt.llvm.org/llvm.sh
+chmod +x llvm.sh
+sudo ./llvm.sh 10
 
 # create conda env
 conda create -n $VIRTUALENV -q --yes python=$VERSION_PYTHON pip cython

--- a/continuous_integration/install_with_blis.sh
+++ b/continuous_integration/install_with_blis.sh
@@ -7,11 +7,11 @@ ABS_PATH=$(pwd)
 popd
 
 # Assume Ubuntu: install a recent version of clang and libomp
-echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
-echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+# echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
+# echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
+# wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo apt update
-sudo apt install clang-8 libomp-8-dev
+sudo apt install clang-10 #libomp-8-dev
 
 # create conda env
 conda create -n $VIRTUALENV -q --yes python=$VERSION_PYTHON pip cython

--- a/continuous_integration/install_with_blis.sh
+++ b/continuous_integration/install_with_blis.sh
@@ -7,9 +7,6 @@ ABS_PATH=$(pwd)
 popd
 
 # Assume Ubuntu: install a recent version of clang and libomp
-# echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
-# echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
-# wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 wget https://apt.llvm.org/llvm.sh
 chmod +x llvm.sh
 sudo ./llvm.sh 10

--- a/continuous_integration/install_with_blis.sh
+++ b/continuous_integration/install_with_blis.sh
@@ -6,7 +6,7 @@ pushd ..
 ABS_PATH=$(pwd)
 popd
 
-# Assume Ubuntu: install a recent version of clang and libomp
+# Install a recent version of clang and libomp
 wget https://apt.llvm.org/llvm.sh
 chmod +x llvm.sh
 sudo ./llvm.sh 10

--- a/continuous_integration/posix.yml
+++ b/continuous_integration/posix.yml
@@ -15,6 +15,8 @@ jobs:
     - script: |
         python3 -m pip install --upgrade pip
         python3 -m pip install flake8
+        echo "installed flake8 !!!"
+        echo "#############################################################"
         python3 -m flake8 .
       displayName: Lint
       condition: eq(variables['LINT'], 'true')

--- a/continuous_integration/posix.yml
+++ b/continuous_integration/posix.yml
@@ -16,7 +16,7 @@ jobs:
         python3 -m pip install --upgrade pip
         echo "#############################################################"
         echo "installing flake8 !!!"
-        python3 -m pip install flake8
+        python3 -m pip install -v flake8
         echo "installed flake8 !!!"
         echo "#############################################################"
         python3 -m flake8 .

--- a/continuous_integration/posix.yml
+++ b/continuous_integration/posix.yml
@@ -14,6 +14,8 @@ jobs:
   steps:
     - script: |
         python3 -m pip install --upgrade pip
+        echo "#############################################################"
+        echo "installing flake8 !!!"
         python3 -m pip install flake8
         echo "installed flake8 !!!"
         echo "#############################################################"

--- a/continuous_integration/posix.yml
+++ b/continuous_integration/posix.yml
@@ -15,13 +15,6 @@ jobs:
     - script: |
         sudo apt-get install python3-flake8
         python3 -m flake8 .
-        # python3 -m pip install --upgrade pip
-        # echo "#############################################################"
-        # echo "installing flake8 !!!"
-        # python3 -m pip install -v flake8
-        # echo "installed flake8 !!!"
-        # echo "#############################################################"
-        # python3 -m flake8 .
       displayName: Lint
       condition: eq(variables['LINT'], 'true')
     - bash: echo "##vso[task.prependpath]$CONDA/bin"

--- a/continuous_integration/posix.yml
+++ b/continuous_integration/posix.yml
@@ -13,13 +13,15 @@ jobs:
 
   steps:
     - script: |
-        python3 -m pip install --upgrade pip
-        echo "#############################################################"
-        echo "installing flake8 !!!"
-        python3 -m pip install -v flake8
-        echo "installed flake8 !!!"
-        echo "#############################################################"
+        sudo apt-get install python3-flake8
         python3 -m flake8 .
+        # python3 -m pip install --upgrade pip
+        # echo "#############################################################"
+        # echo "installing flake8 !!!"
+        # python3 -m pip install -v flake8
+        # echo "installed flake8 !!!"
+        # echo "#############################################################"
+        # python3 -m flake8 .
       displayName: Lint
       condition: eq(variables['LINT'], 'true')
     - bash: echo "##vso[task.prependpath]$CONDA/bin"

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -388,8 +388,8 @@ def test_libomp_libiomp_warning(recwarn):
     info = _threadpool_info()
     prefixes = [module.prefix for module in info]
 
-    if not ("libomp" in prefixes and "libiomp" in prefixes
-            and sys.platform == "linux"):
+    if not ("libomp" in prefixes and "libiomp" in prefixes and
+            sys.platform == "linux"):
         pytest.skip("Requires both libomp and libiomp loaded, on Linux")
 
     assert len(recwarn) == 1

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -212,8 +212,8 @@ class threadpool_limits:
 
         if warning_apis:
             warnings.warn(
-                "Multiple value possible for following user apis: "
-                + ", ".join(warning_apis) + ". Returning the minimum.")
+                "Multiple value possible for following user apis: " +
+                ", ".join(warning_apis) + ". Returning the minimum.")
 
         return num_threads
 


### PR DESCRIPTION
python introduced a compile and link flag that is not supported by old versions of clang (-fno-semantic-interposition).
installing clang 10 fixes it.

the installation of flake8 was not working (don't know why). I just changed the install command.