### PR TITLE
Add OpenBLAS corename detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 ======================
 
 - Report the architecture of the CPU cores detected by OpenBLAS
-  (`openblas_get_corename`) in `threadpool_info()`.
+  (`openblas_get_corename`) in `threadpool_info()` and BLIS
+  (`bli_arch_query_id` and `bli_arch_string`).
 
 2.1.0 (2020-05-29)
 ==================

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 2.2.0 (In development)
 ======================
 
+- Report the architecture of the CPU cores detected by OpenBLAS
+  (`openblas_get_corename`) in `threadpool_info()`.
 
 2.1.0 (2020-05-29)
 ==================

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -453,6 +453,7 @@ def test_architecture():
     expected_blis_architectures = (
         # XXX: add more as needed by CI or developer laptops
         "skx",
+        "haswell",
     )
     for module in threadpool_info():
         if module["internal_api"] == "openblas":

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -446,7 +446,7 @@ def test_architecture():
     expected_openblas_architectures = (
         # XXX: add more as needed by CI or developer laptops
         "armv8",
-        "haswell",
+        "Haswell",
         "SkylakeX",
         "Sandybridge",
     )

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -460,3 +460,6 @@ def test_architecture():
             assert module["architecture"] in expected_openblas_architectures
         elif module["internal_api"] == "blis":
             assert module["architecture"] in expected_blis_architectures
+        else:
+            # Not supported for other modules
+            assert "architecture" not in module

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -440,3 +440,18 @@ def test_command_line_import_flag():
         assert "WARNING: could not import scipy.linalg" in warnings
     else:
         assert "WARNING: could not import scipy.linalg" not in warnings
+
+
+def test_architecture():
+    expected_openblas_architectures = (
+        # XXX: add more as needed by CI or developer laptops
+        "armv8",
+    )
+    expected_blis_architectures = (
+        # XXX: add more as needed by CI or developer laptops
+    )
+    for module in threadpool_info():
+        if module["internal_api"] == "openblas":
+            assert module["architecture"] in expected_openblas_architectures
+        elif module["internal_api"] == "blis":
+            assert module["architecture"] in expected_blis_architectures

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -446,9 +446,13 @@ def test_architecture():
     expected_openblas_architectures = (
         # XXX: add more as needed by CI or developer laptops
         "armv8",
+        "haswell",
+        "SkylakeX",
+        "Sandybridge",
     )
     expected_blis_architectures = (
         # XXX: add more as needed by CI or developer laptops
+        "skx",
     )
     for module in threadpool_info():
         if module["internal_api"] == "openblas":

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -677,6 +677,7 @@ class _OpenBLASModule(_Module):
         get_corename.restype = ctypes.c_char_p
         return get_corename().decode("utf-8")
 
+
 class _BLISModule(_Module):
     """Module class for BLIS"""
     def get_version(self):

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -660,7 +660,7 @@ class _OpenBLASModule(_Module):
 
     def _get_extra_info(self):
         self.threading_layer = self.get_threading_layer()
-        self.corename = self.get_corename()
+        self.architecture = self.get_architecture()
 
     def get_threading_layer(self):
         """Return the threading layer of OpenBLAS"""
@@ -671,9 +671,11 @@ class _OpenBLASModule(_Module):
             return "pthreads"
         return "disabled"
 
-    def get_corename(self):
-        get_corename = getattr(self._dynlib, "openblas_get_corename",
-                               lambda: None)
+    def get_architecture(self):
+        get_corename = getattr(self._dynlib, "openblas_get_corename", None)
+        if get_corename is None:
+            return None
+
         get_corename.restype = ctypes.c_char_p
         return get_corename().decode("utf-8")
 
@@ -701,6 +703,7 @@ class _BLISModule(_Module):
 
     def _get_extra_info(self):
         self.threading_layer = self.get_threading_layer()
+        self.architecture = self.get_architecture()
 
     def get_threading_layer(self):
         """Return the threading layer of BLIS"""
@@ -709,6 +712,18 @@ class _BLISModule(_Module):
         elif self._dynlib.bli_info_get_enable_pthreads():
             return "pthreads"
         return "disabled"
+
+    def get_architecture(self):
+        bli_arch_query_id = getattr(self._dynlib, "bli_arch_query_id", None)
+        bli_arch_string = getattr(self._dynlib, "bli_arch_string", None)
+        if bli_arch_query_id is None or bli_arch_string is None:
+            return None
+
+        # the true restype should be BLIS' arch_t (enum) but int should work
+        # for us:
+        bli_arch_query_id.restype = ctypes.c_int
+        bli_arch_string.restype = ctypes.c_char_p
+        return bli_arch_string(bli_arch_query_id()).decode("utf-8")
 
 
 class _MKLModule(_Module):

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -660,6 +660,7 @@ class _OpenBLASModule(_Module):
 
     def _get_extra_info(self):
         self.threading_layer = self.get_threading_layer()
+        self.corename = self.get_corename()
 
     def get_threading_layer(self):
         """Return the threading layer of OpenBLAS"""
@@ -670,6 +671,11 @@ class _OpenBLASModule(_Module):
             return "pthreads"
         return "disabled"
 
+    def get_corename(self):
+        get_corename = getattr(self._dynlib, "openblas_get_corename",
+                               lambda: None)
+        get_corename.restype = ctypes.c_char_p
+        return get_corename().decode("utf-8")
 
 class _BLISModule(_Module):
     """Module class for BLIS"""


### PR DESCRIPTION
Demo:

```json
$ python -m threadpoolctl -i numpy
[
  {
    "filepath": "/Users/ogrisel/miniforge3/envs/dev/lib/libopenblasp-r0.3.12.dylib",
    "prefix": "libopenblas",
    "user_api": "blas",
    "internal_api": "openblas",
    "version": "0.3.12",
    "num_threads": 8,
    "threading_layer": "openmp",
    "corename": "armv8"
  },
  {
    "filepath": "/Users/ogrisel/miniforge3/envs/dev/lib/libomp.dylib",
    "prefix": "libomp",
    "user_api": "openmp",
    "internal_api": "openmp",
    "version": null,
    "num_threads": 8
  }
]
```