### PR TITLE
Fix import with -OO

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
   missing version query functions.
   https://github.com/joblib/threadpoolctl/pull/88
 
+- Fixed an attribute error when python is run with -OO.
+  https://github.com/joblib/threadpoolctl/pull/87
 
 2.2.0 (2021-07-09)
 ==================

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -98,7 +98,8 @@ _ALL_OPENMP_LIBRARIES = list(
 
 def _format_docstring(*args, **kwargs):
     def decorator(o):
-        o.__doc__ = o.__doc__.format(*args, **kwargs)
+        if o.__doc__ is not None:
+            o.__doc__ = o.__doc__.format(*args, **kwargs)
         return o
 
     return decorator


### PR DESCRIPTION
When python is run with `-OO`, docstrings are removed and `__doc__` is set to `None`. This makes `_format_docstring` fail with the following error:
```
>>> import threadpoolctl
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/peter/miniconda3/lib/python3.8/site-packages/threadpoolctl.py", line 109, in <module>
    def threadpool_info():
  File "/home/peter/miniconda3/lib/python3.8/site-packages/threadpoolctl.py", line 101, in decorator
    o.__doc__ = o.__doc__.format(*args, **kwargs)
AttributeError: 'NoneType' object has no attribute 'format'
```