### PR TITLE
Fix getattr uses with invalid default values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 2.3.0 (in development)
 ======================
 
+- Fixed an attribute error when using old versions of OpenBLAS or BLIS that are
+  missing version query functions.
 
 
 2.2.0 (2021-07-09)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 
 - Fixed an attribute error when using old versions of OpenBLAS or BLIS that are
   missing version query functions.
+  https://github.com/joblib/threadpoolctl/pull/88
 
 
 2.2.0 (2021-07-09)

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -640,8 +640,10 @@ class _OpenBLASModule(_Module):
     def get_version(self):
         # None means OpenBLAS is not loaded or version < 0.3.4, since OpenBLAS
         # did not expose its version before that.
-        get_config = getattr(self._dynlib, "openblas_get_config",
-                             lambda: None)
+        get_config = getattr(self._dynlib, "openblas_get_config", None)
+        if get_config is None:
+            return None
+
         get_config.restype = ctypes.c_char_p
         config = get_config().split()
         if config[0] == b"OpenBLAS":
@@ -683,8 +685,10 @@ class _OpenBLASModule(_Module):
 class _BLISModule(_Module):
     """Module class for BLIS"""
     def get_version(self):
-        get_version_ = getattr(self._dynlib, "bli_info_get_version_str",
-                               lambda: None)
+        get_version_ = getattr(self._dynlib, "bli_info_get_version_str", None)
+        if get_version_ is None:
+            return None
+
         get_version_.restype = ctypes.c_char_p
         return get_version_().decode("utf-8")
 


### PR DESCRIPTION
If the lambdas return None here, then `split` or `decode` will raise, e.g.
```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/threadpoolctl.py", line 400, in match_module_callback
    self._make_module_from_path(filepath)
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/threadpoolctl.py", line 515, in _make_module_from_path
    module = module_class(filepath, prefix, user_api, internal_api)
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/threadpoolctl.py", line 606, in __init__
    self.version = self.get_version()
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/threadpoolctl.py", line 646, in get_version
    config = get_config().split()
AttributeError: 'NoneType' object has no attribute 'split'

```