### PR TITLE
CI use all packages from the conda-forge channel on macos

### DIFF
--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -134,7 +134,7 @@ stages:
           INSTALL_LIBOMP: 'homebrew'
         # MacOS environment with OpenMP installed through conda-forge compilers
         pylatest_conda_conda_forge_clang:
-          PACKAGER: 'conda'
+          PACKAGER: 'conda-forge'
           VERSION_PYTHON: '*'
           BLAS: 'mkl'
           CC_OUTER_LOOP: 'clang'

--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -81,6 +81,7 @@ stages:
         pylatest_conda_forge:
           PACKAGER: 'conda-forge'
           VERSION_PYTHON: '*'
+          BLAS: 'openblas'
           CC_OUTER_LOOP: 'gcc'
           CC_INNER_LOOP: 'gcc'
         # Linux environment with no numpy and heterogeneous OpenMP runtimes.
@@ -133,7 +134,7 @@ stages:
           CC_INNER_LOOP: 'clang'
           INSTALL_LIBOMP: 'homebrew'
         # MacOS environment with OpenMP installed through conda-forge compilers
-        pylatest_conda_conda_forge_clang:
+        pylatest_conda_forge_clang:
           PACKAGER: 'conda-forge'
           VERSION_PYTHON: '*'
           BLAS: 'mkl'

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -19,7 +19,8 @@ make_conda() {
             # Install an OpenMP-enabled clang/llvm from conda-forge
 
             # temporary pin llvm-openmp version. version 12 + mkl segfaults.
-            TO_INSTALL="$TO_INSTALL conda-forge::compilers conda-forge::llvm-openmp<=11.1.0"
+            # TO_INSTALL="$TO_INSTALL conda-forge::compilers conda-forge::llvm-openmp<=11.1.0"
+            TO_INSTALL="$TO_INSTALL compilers llvm-openmp"
 
             export CFLAGS="$CFLAGS -I$CONDA/envs/$VIRTUALENV/include"
             export LDFLAGS="$LDFLAGS -Wl,-rpath,$CONDA/envs/$VIRTUALENV/lib -L$CONDA/envs/$VIRTUALENV/lib"

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -50,7 +50,7 @@ if [[ "$PACKAGER" == "conda" ]]; then
 elif [[ "$PACKAGER" == "conda-forge" ]]; then
     conda config --prepend channels conda-forge
     conda config --set channel_priority strict
-    TO_INSTALL="python=$VERSION_PYTHON numpy scipy"
+    TO_INSTALL="python=$VERSION_PYTHON numpy scipy blas[build=$BLAS]"
     make_conda $TO_INSTALL
 
 elif [[ "$PACKAGER" == "pip" ]]; then

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -18,8 +18,7 @@ make_conda() {
         if [[ "$INSTALL_LIBOMP" == "conda-forge" ]]; then
             # Install an OpenMP-enabled clang/llvm from conda-forge
 
-            # temporary pin llvm-openmp version. version 12 + mkl segfaults.
-            # TO_INSTALL="$TO_INSTALL conda-forge::compilers conda-forge::llvm-openmp<=11.1.0"
+            # assumes conda-forge is set on priority channel
             TO_INSTALL="$TO_INSTALL compilers llvm-openmp"
 
             export CFLAGS="$CFLAGS -I$CONDA/envs/$VIRTUALENV/include"


### PR DESCRIPTION
For the ``pylatest_conda_conda_forge_clang`` job on macos we install `python numpy scipy mkl` from the default channel and `compilers llvm-openmp` from the conda-forge channel. This triggers a segfault with the last version llvm-openmp.

Since it's not advised to mix packages from different channels I think we should no longer care of supporting this and install everything from conda-forge instead.

The difference is that conda-forge forces to only use llvm-openmp so it does not cover the intel-openmp + llvm-openmp case on macos anymore. 