### PR TITLE
Make threadpoolctl robust to missing openblas_get_parallel symbol

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 - Fixed an attribute error when using old versions of OpenBLAS or BLIS that are
   missing version query functions.
   https://github.com/joblib/threadpoolctl/pull/88
+  https://github.com/joblib/threadpoolctl/pull/91
 
 - Fixed an attribute error when python is run with -OO.
   https://github.com/joblib/threadpoolctl/pull/87

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -667,7 +667,11 @@ class _OpenBLASModule(_Module):
 
     def get_threading_layer(self):
         """Return the threading layer of OpenBLAS"""
-        threading_layer = self._dynlib.openblas_get_parallel()
+        openblas_get_parallel = getattr(self._dynlib, "openblas_get_parallel",
+                                        None)
+        if openblas_get_parallel is None:
+            return "unknown"
+        threading_layer = openblas_get_parallel
         if threading_layer == 2:
             return "openmp"
         elif threading_layer == 1:


### PR DESCRIPTION
This is a follow-up to #88.

I got this when testing against the openblas shipped with the [scipy nightly wheel for Apple M1](https://github.com/scipy/scipy/issues/13409#issuecomment-904548388).

