### PR TITLE
MNT use lru_cache for realpath

### DIFF
--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -18,6 +18,7 @@ import textwrap
 import warnings
 from ctypes.util import find_library
 from abc import ABC, abstractmethod
+from functools import lru_cache
 
 __version__ = "2.3.0.dev0"
 __all__ = ["threadpool_limits", "threadpool_info"]
@@ -103,6 +104,12 @@ def _format_docstring(*args, **kwargs):
         return o
 
     return decorator
+
+
+@lru_cache(maxsize=10000)
+def _realpath(filepath):
+    """Small caching wrapper around os.path.realpath to limit system calls"""
+    return os.path.realpath(filepath)
 
 
 @_format_docstring(USER_APIS=list(_ALL_USER_APIS),
@@ -325,12 +332,6 @@ class _ThreadpoolInfo():
     # it's very unlikely that a shared library will be unloaded and reloaded
     # during the lifetime of a program.
     _system_libraries = dict()
-    # Cache for calls to os.path.realpath on system libraries to reduce the
-    # impact of slow system calls (e.g. stat) on slow filesystem.
-    # We use a class level cache instead of an instance level cache because
-    # we can safely assume that the filepath of loaded shared libraries will
-    # never change during the lifetime of a program.
-    _realpaths = dict()
 
     def __init__(self, user_api=None, prefixes=None,  modules=None):
         if modules is None:
@@ -490,7 +491,7 @@ class _ThreadpoolInfo():
     def _make_module_from_path(self, filepath):
         """Store a module if it is supported and selected"""
         # Required to resolve symlinks
-        filepath = self._realpath(filepath)
+        filepath = _realpath(filepath)
         # `lower` required to take account of OpenMP dll case on Windows
         # (vcomp, VCOMP, Vcomp, ...)
         filename = os.path.basename(filepath).lower()
@@ -566,19 +567,6 @@ class _ThreadpoolInfo():
             dll = ctypes.WinDLL("{}.dll".format(dll_name))
             cls._system_libraries[dll_name] = dll
         return dll
-
-    @classmethod
-    def _realpath(cls, filepath, cache_limit=10000):
-        """Small caching wrapper around os.path.realpath to limit system calls
-        """
-        rpath = cls._realpaths.get(filepath)
-        if rpath is None:
-            rpath = os.path.realpath(filepath)
-            if len(cls._realpaths) < cache_limit:
-                # If we drop support for Python 2.7, we could use
-                # functools.lru_cache with maxsize=10000 instead.
-                cls._realpaths[filepath] = rpath
-        return rpath
 
 
 @_format_docstring(


### PR DESCRIPTION
An old comment says we should be using a lru_cache for the real paths when we drop python 2 support. I don't know if we ever supported it but our min python version is currently 3.6.

The benchmarks script ``benchmarks/bench_context_manager_overhead.py `` does not detect any performance change.
master: ``Overhead per call: 0.315 +/-0.071 ms``
this PR: ``Overhead per call: 0.309 +/-0.062 ms``
results are within each other error bounds
