### PR TITLE
ENH Add support for OpenBLAS built for 64bit integers in Fortran

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
   https://github.com/joblib/threadpoolctl/pull/95
 
 - Added support for OpenBLAS built for 64bit integers in Fortran.
+  https://github.com/joblib/threadpoolctl/pull/101
 
 - Fixed an attribute error when using old versions of OpenBLAS or BLIS that are
   missing version query functions.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@
   threads can be limited with the `limit` method which can be used as a context
   manager (equivalent to `threadpoolctl.threadpool_limits()`). This is especially useful
   to avoid searching through all loaded shared libraries each time.
+  https://github.com/joblib/threadpoolctl/pull/95
+
+- Added support for OpenBLAS built for 64bit integers in Fortran.
 
 - Fixed an attribute error when using old versions of OpenBLAS or BLIS that are
   missing version query functions.

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -704,19 +704,34 @@ class OpenBLASController(LibController):
         self.architecture = self._get_architecture()
 
     def get_num_threads(self):
-        get_func = getattr(self._dynlib, "openblas_get_num_threads", lambda: None)
+        get_func = getattr(
+            self._dynlib,
+            "openblas_get_num_threads",
+            # Symbols differ when built for 64bit integers in Fortran
+            getattr(self._dynlib, "openblas_get_num_threads64_", lambda: None),
+        )
+
         return get_func()
 
     def set_num_threads(self, num_threads):
         set_func = getattr(
-            self._dynlib, "openblas_set_num_threads", lambda num_threads: None
+            self._dynlib,
+            "openblas_set_num_threads",
+            # Symbols differ when built for 64bit integers in Fortran
+            getattr(
+                self._dynlib, "openblas_set_num_threads64_", lambda num_threads: None
+            ),
         )
         return set_func(num_threads)
 
     def get_version(self):
         # None means OpenBLAS is not loaded or version < 0.3.4, since OpenBLAS
         # did not expose its version before that.
-        get_config = getattr(self._dynlib, "openblas_get_config", None)
+        get_config = getattr(
+            self._dynlib,
+            "openblas_get_config",
+            getattr(self._dynlib, "openblas_get_config64_", None),
+        )
         if get_config is None:
             return None
 
@@ -728,7 +743,11 @@ class OpenBLASController(LibController):
 
     def _get_threading_layer(self):
         """Return the threading layer of OpenBLAS"""
-        openblas_get_parallel = getattr(self._dynlib, "openblas_get_parallel", None)
+        openblas_get_parallel = getattr(
+            self._dynlib,
+            "openblas_get_parallel",
+            getattr(self._dynlib, "openblas_get_parallel64_", None),
+        )
         if openblas_get_parallel is None:
             return "unknown"
         threading_layer = openblas_get_parallel()
@@ -740,7 +759,11 @@ class OpenBLASController(LibController):
 
     def _get_architecture(self):
         """Return the architecture detected by OpenBLAS"""
-        get_corename = getattr(self._dynlib, "openblas_get_corename", None)
+        get_corename = getattr(
+            self._dynlib,
+            "openblas_get_corename",
+            getattr(self._dynlib, "openblas_get_corename64_", None),
+        )
         if get_corename is None:
             return None
 


### PR DESCRIPTION
In that case, the symbols are suffixed with `64_`.
Fixes #92 

I tested locally with the nightly build of numpy (https://anaconda.org/scipy-wheels-nightly/numpy)

Before this PR `python -m threadpoolctl -i numpy` returned
```
[
  {
    "user_api": "blas",
    "internal_api": "openblas",
    "prefix": "libopenblas",
    "filepath": "/home/jeremie/miniconda/envs/tst-ctl/lib/python3.8/site-packages/numpy.libs/libopenblas64_p-r0-6d9684d7.3.17.so",
    "version": null,
    "num_threads": null,
    "threading_layer": "unknown",
    "architecture": null
  }
]
```

And with this PR
```
[
  {
    "user_api": "blas",
    "internal_api": "openblas",
    "prefix": "libopenblas",
    "filepath": "/home/jeremie/miniconda/envs/tst-ctl/lib/python3.8/site-packages/numpy.libs/libopenblas64_p-r0-6d9684d7.3.17.so",
    "version": "0.3.17",
    "num_threads": 4,
    "threading_layer": "pthreads",
    "architecture": "Haswell"
  }
]
```

(I also checked that the set_num_threads also works as expected).

If numpy/scipy eventually release with this build of OpenBLAS, the CIs with the latest versions of the packages will get this build of OpenBLAS, enabling the tests for the added code in this PR.