### PR TITLE
FEA Add possibility to use threadpool_limits as a decorator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 
 - Added the possibility to use `threadpoolctl.threadpool_limits` and
   `threadpooctl.ThreadpoolController` as decorators through their `wrap` method.
+  https://github.com/joblib/threadpoolctl/pull/102
 
 - Fixed an attribute error when using old versions of OpenBLAS or BLIS that are
   missing version query functions.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@
 - Added support for OpenBLAS built for 64bit integers in Fortran.
   https://github.com/joblib/threadpoolctl/pull/101
 
+- Added the possibility to use `threadpoolctl.threadpool_limits` and
+  `threadpooctl.ThreadpoolController` as decorators through their `wrap` method.
+
 - Fixed an attribute error when using old versions of OpenBLAS or BLIS that are
   missing version query functions.
   https://github.com/joblib/threadpoolctl/pull/88

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ in specific sections of your Python program:
 The threadpools can also be controlled via the object oriented API, which is especially
 useful to avoid searching through all the loaded shared libraries each time. It will
 however not act on libraries loaded after the instanciation of the
-``ThreadpoolController``:
+`ThreadpoolController`:
 
 ```python
 >>> from threadpoolctl import ThreadpoolController
@@ -169,6 +169,27 @@ however not act on libraries loaded after the instanciation of the
 >>> with controller.limit(limits=1, user_api='blas'):
 ...     a = np.random.randn(1000, 1000)
 ...     a_squared = a @ a
+```
+
+### Restricting the limits to the scope of a function
+
+`threadpool_limits` and `ThreadpoolController` can also be used as decorators to set
+the maximum number of threads used by the supported libraries at a function level. The
+decorators are accessible through their `wrap` method:
+
+```python
+>>> from threadpoolctl import ThreadpoolController, threadpool_limits
+>>> import numpy as np
+>>> controller = ThreadpoolController()
+
+>>> @controller.wrap(limits=1, user_api='blas')
+... # or @threadpool_limits.wrap(limits=1, user_api='blas')
+... def my_func():
+...     # Inside this function, calls to blas implementation (like openblas or MKL)
+...     # will be limited to use only one thread.
+...     a = np.random.randn(1000, 1000)
+...     a_squared = a @ a
+...
 ```
 
 ### Known Limitations

--- a/README.md
+++ b/README.md
@@ -214,6 +214,11 @@ decorators are accessible through their `wrap` method:
   and workarounds:
   https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md
 
+- Setting the maximum number of threads of the OpenMP and BLAS libraries has a global
+  effect and impacts the whole Python process. There is no thread level isolation as
+  these libraries do not offer thread-local APIs to configure the number of threads to
+  use in nested parallel calls.
+
 
 ## Maintainers
 

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -595,8 +595,10 @@ def test_threadpool_controller_as_decorator():
     controller = ThreadpoolController()
     original_info = controller.info()
 
+    if any(info["num_threads"] < 2 for info in original_info):
+        pytest.skip("Test requires at least 2 CPUs on host machine")
     if not controller.select(user_api="blas"):
-        pytest.skip(f"Requires a blas runtime.")
+        pytest.skip("Requires a blas runtime.")
 
     def check_blas_num_threads(expected_num_threads):
         blas_controller = ThreadpoolController().select(user_api="blas")

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -576,6 +576,7 @@ def test_threadpool_controller_as_decorator():
     # Check that using the decorator can be nested and is restricted to the scope of
     # the decorated function.
     controller = ThreadpoolController()
+    original_info = controller.info()
 
     if not controller.select(user_api="blas"):
         pytest.skip(f"Requires a blas runtime.")
@@ -589,12 +590,14 @@ def test_threadpool_controller_as_decorator():
 
     @controller.wrap(limits=1, user_api="blas")
     def outer_func():
-        _check_blas_num_threads(1)
+        check_blas_num_threads(1)
         inner_func()
-        _check_blas_num_threads(1)
+        check_blas_num_threads(1)
 
     @controller.wrap(limits=2, user_api="blas")
     def inner_func():
-        _check_blas_num_threads(2)
+        check_blas_num_threads(2)
 
-    assert controller.info() == ThreadpoolController().info()
+    outer_func()
+
+    assert ThreadpoolController().info() == original_info

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -315,6 +315,10 @@ class threadpool_limits(_ThreadpoolLimiter):
     the supported libraries to `limit`. This function works for libraries that
     are already loaded in the interpreter and can be changed dynamically.
 
+    This effect is global and impacts the whole Python process. There is no thread level
+    isolation as these libraries do not offer thread-local APIs to configure the number
+    of threads to use in nested parallel calls.
+
     Parameters
     ----------
     limits : int, dict or None (default=None)
@@ -428,6 +432,10 @@ class ThreadpoolController:
         Set the maximal number of threads that can be used in thread pools used in
         the supported libraries to `limits`. This function works for libraries that
         are already loaded in the interpreter and can be changed dynamically.
+
+        This effect is global and impacts the whole Python process. There is no thread
+        level isolation as these libraries do not offer thread-local APIs to configure
+        the number of threads to use in nested parallel calls.
 
         Parameters
         ----------

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -163,7 +163,9 @@ class _threadpool_limits:
     @classmethod
     def wrap(cls, controller, *, limits=None, user_api=None):
         """Return an instance of this class that can be used as a decorator"""
-        return _threadpool_limits_decorator(controller=controller, limits=limits, user_api=user_api)
+        return _threadpool_limits_decorator(
+            controller=controller, limits=limits, user_api=user_api
+        )
 
     def unregister(self):
         for lib_controller in self._controller.lib_controllers:
@@ -279,6 +281,7 @@ class _threadpool_limits:
 
 class _threadpool_limits_decorator(_threadpool_limits, ContextDecorator):
     """Same as _threadpool_limits but to be used as a decorator"""
+
     def __init__(self, controller, *, limits=None, user_api=None):
         self._limits, self._user_api, self._prefixes = self._check_params(
             limits, user_api

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -464,6 +464,11 @@ class ThreadpoolController:
         """
         return _ThreadpoolLimiter(self, limits=limits, user_api=user_api)
 
+    @_format_docstring(
+        USER_APIS=", ".join('"{}"'.format(api) for api in _ALL_USER_APIS),
+        BLAS_LIBS=", ".join(_ALL_BLAS_LIBRARIES),
+        OPENMP_LIBS=", ".join(_ALL_OPENMP_LIBRARIES),
+    )
     def wrap(self, *, limits=None, user_api=None):
         """Change the maximal number of threads that can be used in thread pools.
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -213,8 +213,7 @@ class _ThreadpoolLimiter:
 
         return num_threads
 
-    @classmethod
-    def _check_params(cls, limits, user_api):
+    def _check_params(self, limits, user_api):
         """Suitable values for the _limits, _user_api and _prefixes attributes"""
         if limits is None or isinstance(limits, int):
             if user_api is None:
@@ -347,9 +346,7 @@ class threadpool_limits(_ThreadpoolLimiter):
 
     @classmethod
     def wrap(cls, limits=None, user_api=None):
-        return super().wrap(
-            ThreadpoolController(), limits=limits, user_api=user_api
-        )
+        return super().wrap(ThreadpoolController(), limits=limits, user_api=user_api)
 
 
 @_format_docstring(

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -337,10 +337,12 @@ class threadpool_limits(_threadpool_limits):
 
     def __init__(self, limits=None, user_api=None):
         super().__init__(ThreadpoolController(), limits=limits, user_api=user_api)
-    
+
     @classmethod
     def wrap(cls, limits=None, user_api=None):
-        return _threadpool_limits.wrap(ThreadpoolController(), limits=limits, user_api=user_api)
+        return _threadpool_limits.wrap(
+            ThreadpoolController(), limits=limits, user_api=user_api
+        )
 
 
 @_format_docstring(

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -145,6 +145,9 @@ class _ThreadpoolLimiter:
     Refer to the docstring of ThreadpoolController.limit for more details.
 
     It will only act on the library controllers held by the provided `controller`.
+    Using the default constructor sets the limits right away such that it can be used as
+    a callable. Setting the limits can be delayed by using the `wrap` class method such
+    that it can be used as a decorator.
     """
 
     def __init__(self, controller, *, limits=None, user_api=None):


### PR DESCRIPTION
Fixes #69 

Introduces `threadpool_limits.wrap(limits, user_api)` and `ThreadpoolController().wrap(limits, user_api)` that can be used as decorators to restrict their scope to the scope of the decorated function.

```py
from threadpoolctl import ThreadpoolController

controller = ThreadpoolController()

@controller.wrap(limits=1, user_api="blas")
def my_func():
     # Single threaded blas inside the function
     X @ Y
```

or
```py
from threadpoolctl import threadpool_limits

@threadpool_limits.wrap(limits=1, user_api="blas")
def my_func():
     # Single threaded blas inside the function
     X @ Y
```