### PR TITLE
FIX make the num_threads attribute dynamic

### DIFF
--- a/tests/_openmp_test_helper/nested_prange_blas.pyx
+++ b/tests/_openmp_test_helper/nested_prange_blas.pyx
@@ -43,12 +43,12 @@ def check_nested_prange_blas(double[:, ::1] A, double[:, ::1] B, int nthreads):
         int prange_num_threads
         int *prange_num_threads_ptr = &prange_num_threads
 
-    inner_controller = [None]
+    inner_info = [None]
 
     with nogil, parallel(num_threads=nthreads):
         if openmp.omp_get_thread_num() == 0:
             with gil:
-                inner_controller[0] = ThreadpoolController()
+                inner_info[0] = ThreadpoolController().info()
 
             prange_num_threads_ptr[0] = openmp.omp_get_num_threads()
 
@@ -62,4 +62,4 @@ def check_nested_prange_blas(double[:, ::1] A, double[:, ::1] B, int nthreads):
                     &alpha, &B[0, 0], &k, &A[i * chunk_size, 0], &k,
                     &beta, &C[i * chunk_size, 0], &n)
 
-    return np.asarray(C), prange_num_threads, inner_controller[0]
+    return np.asarray(C), prange_num_threads, inner_info[0]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -65,3 +65,19 @@ def threadpool_info_from_subprocess(module):
     cmd = [sys.executable, "-m", "threadpoolctl", "-i", module]
     out = check_output(cmd, env=env).decode("utf-8")
     return json.loads(out)
+
+
+def select(info, **kwargs):
+    """Select a subset of the list of library info matching the request"""
+    # It's just a utility function to avoid repeating the pattern
+    # [lib_info for lib_info in info if lib_info["<key>"] == key]
+    for key, vals in kwargs.items():
+        kwargs[key] = [vals] if not isinstance(vals, list) else vals
+
+    selected_info = [
+        lib_info
+        for lib_info in info
+        if any(lib_info.get(key, None) in vals for key, vals in kwargs.items())
+    ]
+
+    return selected_info


### PR DESCRIPTION
Found a bug while working on #102 when nesting `ThreadpoolController.limit` context managers.

Since the controller holds the orignal num_threads from when it was created, restoring the limits when exiting the inner context sets the limits back to the original value from before the outer context instead of from within the outer context.
For that we need to retrieve and store the current state of the threadpools when entering the context.
It causes a slowdown from ~2us to ~10us, but we don't have a choice and it's still much faster that the ~300us of `threadpool_limits`

This bug made me also think that having the `num_threads` attribute being static is confusing and might lead to unexpected behavior. for instance:
```py
controller = ThreadpoolController()
controller.info()  # original_info, e.g. num_threads = 4

threadpool_limits(limits=1)
controller.info() # still num_threads = 4
```

I propose to make the `num_threads` attribute of the library controllers dynamic, by calling `get_num_threads` each time we want to access it, such that it reflects the current state of the threadpools.

This change requires a lot of rewriting in the test because it used to rely a lot on the fact that the controller holds the original num_threads. Now we store the original info from `controller.info()` and use it to check that we restore the limits to their correct value.