### PR TITLE
Add VORTEX to test_architecture

### DIFF
--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -554,6 +554,7 @@ def test_architecture():
         "Haswell",
         "SkylakeX",
         "Sandybridge",
+        "VORTEX",
         "Zen",
     )
     expected_blis_architectures = (


### PR DESCRIPTION
Similar to #110 for macOS/arm64 developers.