### PR TITLE
MNT Use flit_core build-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit"]
-build-backend = "flit.buildapi"
+requires = ["flit_core"]
+build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]
 module = "threadpoolctl"


### PR DESCRIPTION
Use flit_core build-backend instead of flit per upstream
recommendations.  flit_core provides the core package building
functionality without the complete package manager flit provides.
Since it has fewer dependencies, it makes package building much faster.