### PR TITLE
TST Avoid side effects in test suite

### DIFF
--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -548,15 +548,9 @@ def test_command_line_command_flag():
         [sys.executable, "-m", "threadpoolctl", "-c", "import numpy"]
     )
     cli_info = json.loads(output.decode("utf-8"))
+
     this_process_info = threadpool_info()
-
-    from pprint import pprint
-    pprint(this_process_info)
-
     for lib_info in cli_info:
-        pprint(lib_info)
-        print(lib_info["internal_api"], lib_info in this_process_info)
-
         assert lib_info in this_process_info
 
 

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -441,7 +441,6 @@ def test_nested_prange_blas(nthreads_outer):
     A = np.ones((1000, 10))
     B = np.ones((100, 10))
 
-
     with threadpool_limits(limits=1) as threadpoolctx:
         max_threads = threadpoolctx.get_original_num_threads()["openmp"]
         nthreads = effective_num_threads(nthreads_outer, max_threads)


### PR DESCRIPTION
`test_threadpool_controller_limit` had a side effect when using OpenBLAS with the OpenMP threading layer.

There must have been a change in the numpy or openblas init, such that now openblas num_threads is 1 after numpy import and only switches to the number of cores after the openmp threadpool is initialized (doing a big matrix multiplication for instance). So what's going on is:

initially:
Openblas num_threads: 1
OpenMP num_threads: 4

with blas_controller.limit(limits=1)   
Openblas num_threads: 1
OpenMP num_threads: 1  # set both limits to 1 even if it's only the openblas controller (see https://github.com/xianyi/OpenBLAS/issues/2985)

finally:
Openblas num_threads: 1
OpenMP num_threads: 1  # instead of 4 because the ctx only reset for OpenBLAS to its original value which also set's the OpenMP limit for the same reason as above.


This PR: skip the test when OpenBLAS with the OpenMP threading layer to avoid the side effect that impacts following tests. The assertion of the test was already not tested in this case anyway.
