### PR TITLE
MAINT whitelist test_multiple_openblas for check_no_test_always_skipped

### DIFF
--- a/continuous_integration/check_no_test_skipped.py
+++ b/continuous_integration/check_no_test_skipped.py
@@ -33,11 +33,20 @@ for name in os.listdir(base_dir):
                 always_skipped[test_name] = skipped
 
 print("\n------------------------------------------------------------------\n")
+
+# List of tests that we don't want to fail the CI if they are skipped in
+# every job. This is useful for tests that depend on specific versions of
+# numpy or scipy and we don't want to pin old versions of these libraries.
+SAFE_SKIPPED_TESTS = ["test_multiple_shipped_openblas"]
+
 fail = False
 for test, skipped in always_skipped.items():
     if skipped:
-        fail = True
-        print(test, "was skipped in every job")
+        if test in SAFE_SKIPPED_TESTS:
+            print(test, "was skipped in every job but it's fine to skip it")
+        else:
+            fail = True
+            print(test, "was skipped in every job")
 
 if fail:
     sys.exit(1)


### PR DESCRIPTION
`test_multiple_openmp` checks that we end up with 2 different openblas with numpy and scipy. However it can happen that all the CI jobs have versions of these 2 libs that are in sync with their openblas versions.

We don't want to maintain a pin on specific versions of numpy and scipy only to trigger this situation. Instead, we'd rather just ignore this test in the check. If at some point the situation happens again the test will still be here and will hopefully still pass :)