### PR TITLE
FEA Support custom lib controllers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,14 @@
-# Python and Cython generated files
+# Python generated files
 *.pyc
 __pycache__
 .cache
 .pytest_cache
+
+# Cython/C generated files
+*.o
 *.so
 *.dylib
-*.c
+tests/_openmp_test_helper/*.c
 
 # Python install files, build and release artifacts
 *.egg-info/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@
 
 - Dropped support for Python 3.6 and 3.7.
 
+- Added support for custom library controllers. Custom controllers must inherit from
+  the `threadpoolctl.LibController` class and be registered to threadpoolctl using the
+  `threadpoolctl.register` function.
+  https://github.com/joblib/threadpoolctl/pull/138
+
 3.1.0 (2022-01-31)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,20 @@ decorators are accessible through their `wrap` method:
 ...
 ```
 
+### Writing a custom library controller
+
+Currently, `threadpoolctl` has support for `OpenMP` and the main `BLAS` libraries.
+However it can also be used to control the threadpool of other native libraries,
+provided that they expose an API to get and set the limit on the number of threads.
+For that, one must implement a controller for this library and register it to
+`threadpoolctl`.
+
+A custom controller must be a subclass of the `LibController` class and implement
+the attributes and methods described in the docstring of `LibController`. Then this
+new controller class must be registered using the `threadpoolctl.register` function.
+An complete example can be found [here](
+  https://github.com/joblib/threadpoolctl/blob/master/tests/_pyMylib/__init__.py).
+
 ### Sequential BLAS within OpenMP parallel region
 
 When one wants to have sequential BLAS calls within an OpenMP parallel region, it's

--- a/continuous_integration/build_test_ext.sh
+++ b/continuous_integration/build_test_ext.sh
@@ -2,6 +2,14 @@
 
 set -e
 
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    pushd tests/_pyMylib
+    rm -rf *.so *.o
+    gcc -c -Wall -Werror -fpic -o my_threaded_lib.o my_threaded_lib.c
+    gcc -shared -o my_threaded_lib.so my_threaded_lib.o
+    popd
+fi
+
 pushd tests/_openmp_test_helper
 rm -rf *.c *.so *.dylib build/
 python setup_inner.py build_ext -i

--- a/continuous_integration/install_with_blis.sh
+++ b/continuous_integration/install_with_blis.sh
@@ -42,7 +42,7 @@ library_dirs = $ABS_PATH/BLIS_install/lib
 include_dirs = $ABS_PATH/BLIS_install/include/blis
 runtime_library_dirs = $ABS_PATH/BLIS_install/lib" > site.cfg
 python setup.py build_ext -i
-pip install --no-build-isolation --no-use-e .
+pip install --no-build-isolation -e .
 popd
 
 popd

--- a/continuous_integration/install_with_blis.sh
+++ b/continuous_integration/install_with_blis.sh
@@ -42,7 +42,7 @@ library_dirs = $ABS_PATH/BLIS_install/lib
 include_dirs = $ABS_PATH/BLIS_install/include/blis
 runtime_library_dirs = $ABS_PATH/BLIS_install/lib" > site.cfg
 python setup.py build_ext -i
-pip install -e .
+pip install --no-build-isolation --no-use-e .
 popd
 
 popd

--- a/continuous_integration/install_with_blis.sh
+++ b/continuous_integration/install_with_blis.sh
@@ -42,7 +42,7 @@ library_dirs = $ABS_PATH/BLIS_install/lib
 include_dirs = $ABS_PATH/BLIS_install/include/blis
 runtime_library_dirs = $ABS_PATH/BLIS_install/lib" > site.cfg
 python setup.py build_ext -i
-pip install --no-build-isolation -e .
+pip install -e .
 popd
 
 popd

--- a/tests/_pyMylib/__init__.py
+++ b/tests/_pyMylib/__init__.py
@@ -14,13 +14,13 @@ class MyThreadedLibController(LibController):
     filename_prefixes = ("my_threaded_lib",)
 
     def get_num_threads(self):
-        return getattr(self._dynlib, "mylib_get_num_threads")()
+        return getattr(self.dynlib, "mylib_get_num_threads")()
 
     def set_num_threads(self, num_threads):
-        getattr(self._dynlib, "mylib_set_num_threads")(num_threads)
+        getattr(self.dynlib, "mylib_set_num_threads")(num_threads)
 
     def get_version(self):
-        get_version = getattr(self._dynlib, "mylib_get_version")
+        get_version = getattr(self.dynlib, "mylib_get_version")
         get_version.restype = ctypes.c_char_p
         return get_version().decode("utf-8")
 

--- a/tests/_pyMylib/__init__.py
+++ b/tests/_pyMylib/__init__.py
@@ -9,22 +9,37 @@ ctypes.CDLL(path)
 
 
 class MyThreadedLibController(LibController):
+    # names for threadpoolctl's context filtering
     user_api = "my_threaded_lib"
     internal_api = "my_threaded_lib"
+
+    # Patterns to identify the name of the linked library to load.
+    # If a dynamic library with a matching filename is linked to the python
+    # process, it will be loaded as the `dynlib` attribute of the LibController
+    # instance.
     filename_prefixes = ("my_threaded_lib",)
 
     def get_num_threads(self):
+        # This function should return the current maximum number of threads,
+        # which is reported as "num_threads" by `ThreadpoolController.info`.
         return getattr(self.dynlib, "mylib_get_num_threads")()
 
     def set_num_threads(self, num_threads):
+        # This function limits the maximum number of threads,
+        # when `ThreadpoolController.limit` is called.
         getattr(self.dynlib, "mylib_set_num_threads")(num_threads)
 
     def get_version(self):
+        # This function returns the version of the linked library if it is exposed,
+        # which is reported as "version" by `ThreadpoolController.info`.
         get_version = getattr(self.dynlib, "mylib_get_version")
         get_version.restype = ctypes.c_char_p
         return get_version().decode("utf-8")
 
     def set_additional_attributes(self):
+        # This function is called during the initialization of the LibController.
+        # Additional information meant to be exposed by `ThreadpoolController.info`
+        # should be set here as attributes of the LibController instance.
         self.some_attr = "some_value"
 
 

--- a/tests/_pyMylib/__init__.py
+++ b/tests/_pyMylib/__init__.py
@@ -1,0 +1,28 @@
+import ctypes
+from pathlib import Path
+
+from threadpoolctl import LibController, register
+
+
+path = Path(__file__).parent / "my_threaded_lib.so"
+ctypes.CDLL(path)
+
+
+class MyThreadedLibController(LibController):
+    user_api = "my_threaded_lib"
+    internal_api = "my_threaded_lib"
+    filename_prefixes = ("my_threaded_lib",)
+
+    def get_num_threads(self):
+        return getattr(self._dynlib, "mylib_get_num_threads")()
+
+    def set_num_threads(self, num_threads):
+        getattr(self._dynlib, "mylib_set_num_threads")(num_threads)
+
+    def get_version(self):
+        get_version = getattr(self._dynlib, "mylib_get_version")
+        get_version.restype = ctypes.c_char_p
+        return get_version().decode("utf-8")
+
+
+register(MyThreadedLibController)

--- a/tests/_pyMylib/__init__.py
+++ b/tests/_pyMylib/__init__.py
@@ -24,5 +24,8 @@ class MyThreadedLibController(LibController):
         get_version.restype = ctypes.c_char_p
         return get_version().decode("utf-8")
 
+    def set_additional_attributes(self):
+        self.some_attr = "some_value"
+
 
 register(MyThreadedLibController)

--- a/tests/_pyMylib/my_threaded_lib.c
+++ b/tests/_pyMylib/my_threaded_lib.c
@@ -1,0 +1,17 @@
+int NUM_THREADS = 42;
+int* NUM_THREADS_p = &NUM_THREADS;
+
+
+int mylib_get_num_threads(){
+    return *NUM_THREADS_p;
+}
+
+
+void mylib_set_num_threads(int num_threads){
+    *NUM_THREADS_p = num_threads;
+}
+
+
+char* mylib_get_version(){
+    return "2.0";
+}

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -695,6 +695,9 @@ def test_custom_controller():
     assert mylib_controller.version == "2.0"
     assert mylib_controller.num_threads == 42
 
+    # my_threaded_lib exposes an additional info "some_attr":
+    assert mylib_controller.info()["some_attr"] == "some_value"
+
     with controller.limit(limits=1, user_api="my_threaded_lib"):
         assert mylib_controller.num_threads == 1
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -219,6 +219,7 @@ class BLISController(LibController):
     user_api = "blas"
     internal_api = "blis"
     filename_prefixes = ("libblis", "libblas")
+    check_symbols = ("bli_thread_get_num_threads",)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -73,9 +73,10 @@ class LibController(ABC):
     A library controller must expose the following class attributes:
         - user_api : str
             Usually the name of the library or generic specification the library
-            implements.
+            implements, e.g. "blas" is a specification with different implementations.
         - internal_api : str
-            Usually the name of the library, or concrete implementation of some
+            Usually the name of the library or concrete implementation of some
+            specification, e.g. "openblas" is an implementation of the "blas"
             specification.
         - filename_prefixes : tuple
             Possible prefixes of the shared library's filename that allow to

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -92,7 +92,7 @@ class LibController(ABC):
     of the shared library to implement the above methods.
 
     The following information will be exposed in the info dictionary:
-      - user_api : user API.
+      - user_api : standardized API, if any, or a copy of internal_api.
       - internal_api : internal API.
       - num_threads : the current thread limit.
       - prefix : prefix of the shared library's filename.

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -93,7 +93,7 @@ class LibController(ABC):
 
     The following information will be exposed in the info dictionary:
       - user_api : standardized API, if any, or a copy of internal_api.
-      - internal_api : internal API.
+      - internal_api : implementation-specific API.
       - num_threads : the current thread limit.
       - prefix : prefix of the shared library's filename.
       - filepath : path to the loaded shared library.

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -102,6 +102,7 @@ class LibController(ABC):
 
     @final
     def __init__(self, *, filepath=None, prefix=None):
+        """This is not meant to be overriden by subclasses."""
         self.prefix = prefix
         self.filepath = filepath
         self.dynlib = ctypes.CDLL(filepath, mode=_RTLD_NOLOAD)
@@ -110,7 +111,10 @@ class LibController(ABC):
 
     @final
     def info(self):
-        """Return relevant info wrapped in a dict"""
+        """Return relevant info wrapped in a dict
+
+        This is not meant to be overriden by subclasses.
+        """
         exposed_attrs = {
             "user_api": self.user_api,
             "internal_api": self.internal_api,
@@ -124,23 +128,11 @@ class LibController(ABC):
         """Set additional attributes meant to be exposed in the info dict"""
 
     @property
-    @abstractmethod
-    def user_api(self):
-        """User API of the library"""
-
-    @property
-    @abstractmethod
-    def internal_api(self):
-        """Internal API of the library"""
-
-    @property
-    @abstractmethod
-    def filename_prefixes(self):
-        """Possible prefixes of the library's filename"""
-
-    @property
-    @final
     def num_threads(self):
+        """Exposes the current thread limit as a dynamic property
+
+        This is not meant to be used or overriden by subclasses.
+        """
         return self.get_num_threads()
 
     @abstractmethod

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -80,7 +80,7 @@ class LibController(ABC):
         - filename_prefixes : tuple
             Possible prefixes of the shared library's filename that allow to
             identify the library. e.g. "libopenblas" for libopenblas.so.
-    
+
     A library contoller must implement the following methods: `get_num_threads`,
     `set_num_threads` and `get_version`.
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -82,14 +82,16 @@ class LibController(ABC):
             Possible prefixes of the shared library's filename that allow to
             identify the library. e.g. "libopenblas" for libopenblas.so.
 
-    A library contoller must implement the following methods: `get_num_threads`,
-    `set_num_threads` and `get_version`.
+    and implement the following methods: `get_num_threads`, `set_num_threads` and
+    `get_version`.
 
-    This class provides a `dynlib` attribute that holds the loaded shared library as a
-    `ctypes.CDLL` object. It can be used to access the necessary symbols of the shared
-    library to implement the above methods.
+    Threadpoolctl loops through all the loaded shared libraries and tries to match
+    the filename of each library with the `filename_prefixes`. If a match is found, a
+    controller is instantiated and a handler to the library is stored in the `dynlib`
+    attribute as a `ctypes.CDLL` object. It can be used to access the necessary symbols
+    of the shared library to implement the above methods.
 
-    The following information will be exposed in the info dict:
+    The following information will be exposed in the info dictionary:
       - user_api : user API.
       - internal_api : internal API.
       - num_threads : the current thread limit.
@@ -98,7 +100,7 @@ class LibController(ABC):
       - version : version of the library (if available).
 
     In addition, each library controller may expose internal API specific entries. They
-    must be set as attributes in the `set_additional_attributes method`.
+    must be set as attributes in the `set_additional_attributes` method.
     """
 
     @final


### PR DESCRIPTION
Fixes https://github.com/joblib/threadpoolctl/issues/137

The goal is to expose the `LibController` abstract class, and custom controllers should inherit from it. This PR also exposes a new function `register` that simply adds the custom controller to the list of controllers to try.

TODO:
- [x] documentation