### PR TITLE
DOC Warn if coexisting libomp / libiomp on MacOS

### DIFF
--- a/multiple_openmp.md
+++ b/multiple_openmp.md
@@ -29,13 +29,13 @@ program**. For instance, on Linux, we never observed any issue between
 `libgomp` and `libiomp`, which is the most common mix (NumPy with MKL + a
 package compiled with GCC, the most widely used C compiler on that platform).
 
-## Incompatibility between Intel OpenMP and LLVM OpenMP under Linux
+## Incompatibility between Intel OpenMP and LLVM OpenMP
 
 The only unrecoverable incompatibility we encountered happens when loading a
 mix of compiled extensions linked with **`libomp` (LLVM/Clang) and `libiomp`
-(ICC), on Linux**, manifested by crashes or deadlocks. It can happen even with
-the simplest OpenMP calls like getting the maximum number of threads that will
-be used in a subsequent parallel region. A possible explanation is that
+(ICC), on Linux and MacOS**, manifested by crashes or deadlocks. It can happen
+even with the simplest OpenMP calls like getting the maximum number of threads
+that will be used in a subsequent parallel region. A possible explanation is that
 `libomp` is actually a fork of `libiomp` causing name colliding for instance.
 Using `threadpoolctl` may crash your program in such a setting.
 
@@ -43,10 +43,7 @@ Using `threadpoolctl` may crash your program in such a setting.
 binary distributions of Python packages for Linux use either GCC or ICC to
 build the Python scientific packages. Therefore this problem would only happen
 if some packagers decide to start shipping Python packages built with
-LLVM/Clang instead of GCC.
-
-Surprisingly, we never encountered this kind of issue on macOS, where this mix
-is the most frequent (Clang being the default C compiler on macOS).
+LLVM/Clang instead of GCC (this is the case for instance with conda's default channel).
 
 ## Workarounds for Intel OpenMP and LLVM OpenMP case
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -742,13 +742,8 @@ class ThreadpoolController:
 
     def _warn_if_incompatible_openmp(self):
         """Raise a warning if llvm-OpenMP and intel-OpenMP are both loaded"""
-        if sys.platform != "linux":
-            # Only raise the warning on linux
-            return
-
         prefixes = [lib_controller.prefix for lib_controller in self.lib_controllers]
-        msg = textwrap.dedent(
-            """
+        msg = textwrap.dedent("""
             Found Intel OpenMP ('libiomp') and LLVM OpenMP ('libomp') loaded at
             the same time. Both libraries are known to be incompatible and this
             can cause random crashes or deadlocks on Linux when loaded in the
@@ -756,8 +751,7 @@ class ThreadpoolController:
             Using threadpoolctl may cause crashes or deadlocks. For more
             information and possible workarounds, please see
                 https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md
-            """
-        )
+            """)
         if "libomp" in prefixes and "libiomp" in prefixes:
             warnings.warn(msg, RuntimeWarning)
 
@@ -769,9 +763,11 @@ class ThreadpoolController:
             libc_name = find_library("c")
             if libc_name is None:  # pragma: no cover
                 warnings.warn(
-                    "libc not found. The ctypes module in Python "
-                    f"{sys.version_info.major}.{sys.version_info.minor} is maybe too "
-                    "old for this OS.",
+                    (
+                        "libc not found. The ctypes module in Python"
+                        f" {sys.version_info.major}.{sys.version_info.minor} is maybe"
+                        " too old for this OS."
+                    ),
                     RuntimeWarning,
                 )
                 return None

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -743,7 +743,8 @@ class ThreadpoolController:
     def _warn_if_incompatible_openmp(self):
         """Raise a warning if llvm-OpenMP and intel-OpenMP are both loaded"""
         prefixes = [lib_controller.prefix for lib_controller in self.lib_controllers]
-        msg = textwrap.dedent("""
+        msg = textwrap.dedent(
+            """
             Found Intel OpenMP ('libiomp') and LLVM OpenMP ('libomp') loaded at
             the same time. Both libraries are known to be incompatible and this
             can cause random crashes or deadlocks on Linux when loaded in the
@@ -751,7 +752,8 @@ class ThreadpoolController:
             Using threadpoolctl may cause crashes or deadlocks. For more
             information and possible workarounds, please see
                 https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md
-            """)
+            """
+        )
         if "libomp" in prefixes and "libiomp" in prefixes:
             warnings.warn(msg, RuntimeWarning)
 
@@ -763,11 +765,9 @@ class ThreadpoolController:
             libc_name = find_library("c")
             if libc_name is None:  # pragma: no cover
                 warnings.warn(
-                    (
-                        "libc not found. The ctypes module in Python"
-                        f" {sys.version_info.major}.{sys.version_info.minor} is maybe"
-                        " too old for this OS."
-                    ),
+                    "libc not found. The ctypes module in Python "
+                    f"{sys.version_info.major}.{sys.version_info.minor} is maybe too "
+                    "old for this OS.",
                     RuntimeWarning,
                 )
                 return None


### PR DESCRIPTION
related to https://github.com/ContinuumIO/anaconda-issues/issues/13221
and https://github.com/scikit-learn-contrib/imbalanced-learn/issues/984

Looks like it's possible to have some crashes due to both libraries coexisting in the same python program on MacOS afterall.

I removed the linux only filter for the warning, but then it means all macos users installing from conda default channel will get this warning. Is it something that we want ?