### PR TITLE
FIX check symbols to better identify supported libraries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+3.2.1 (TBD)
+===========
+
+- Fixed a bug where an unsupported library would be detected because it shares a common
+  prefix with one of the supported libraries. Now the symbols are also checked to
+  identify the supported libraries.
+  https://github.com/joblib/threadpoolctl/pull/151
+
 3.2.0 (2023-07-13)
 ==================
 

--- a/continuous_integration/install_with_blis.sh
+++ b/continuous_integration/install_with_blis.sh
@@ -35,6 +35,7 @@ popd
 # build & install numpy
 git clone https://github.com/numpy/numpy.git
 pushd numpy
+git checkout v1.26.0  # pin numpy < 2 for now
 git submodule update --init
 echo "[blis]
 libraries = blis

--- a/tests/_pyMylib/__init__.py
+++ b/tests/_pyMylib/__init__.py
@@ -19,6 +19,14 @@ class MyThreadedLibController(LibController):
     # instance.
     filename_prefixes = ("my_threaded_lib",)
 
+    # (Optional) Symbols that the linked library is expected to expose. It is used along
+    # with the `filename_prefixes` to make sure that the correct library is identified.
+    check_symbols = (
+        "mylib_get_num_threads",
+        "mylib_set_num_threads",
+        "mylib_get_version",
+    )
+
     def get_num_threads(self):
         # This function should return the current maximum number of threads,
         # which is reported as "num_threads" by `ThreadpoolController.info`.


### PR DESCRIPTION
Fixes #149 

This PR proposes to check that at least 1 of the symbols we're looking for exists the make sure that a library having a matching prefix is actually a supported library (and not a library with a common prefix).

We can't really check that all symbols exist because:
- libs can come with a different set of symbols (e.g. OpenBLAS built for 64bit)
- libs may not expose all the symbols depending of their version, in which case we only show the info we're able to gather.

I'm not sure it's worth trying to install a library the used to trigger the bug in our CI just to test that. I did not find an easy way to install bliss for instance (at least, the way I found didn't come with a libbliss dso)...