### PR TITLE
TST Remove cython conditional compilation

### DIFF
--- a/continuous_integration/install_with_blis.sh
+++ b/continuous_integration/install_with_blis.sh
@@ -35,6 +35,7 @@ popd
 # build & install numpy
 git clone https://github.com/numpy/numpy.git
 pushd numpy
+git checkout v1.26.0 # pin numpy < 2 for now
 git submodule update --init
 echo "[blis]
 libraries = blis

--- a/tests/_openmp_test_helper/nested_prange_blas_blis.pyx
+++ b/tests/_openmp_test_helper/nested_prange_blas_blis.pyx
@@ -31,6 +31,9 @@ def check_nested_prange_blas(double[:, ::1] A, double[:, ::1] B, int nthreads):
         int n_chunks = 100
         int chunk_size = A.shape[0] // n_chunks
 
+        double alpha = 1.0
+        double beta = 0.0
+
         int i
         int prange_num_threads
         int *prange_num_threads_ptr = &prange_num_threads

--- a/tests/_openmp_test_helper/nested_prange_blas_blis.pyx
+++ b/tests/_openmp_test_helper/nested_prange_blas_blis.pyx
@@ -2,7 +2,20 @@ cimport openmp
 from cython.parallel import parallel, prange
 
 import numpy as np
-from scipy.linalg.cython_blas cimport dgemm
+
+cdef extern from 'cblas.h' nogil:
+    ctypedef enum CBLAS_ORDER:
+        CblasRowMajor=101
+        CblasColMajor=102
+    ctypedef enum CBLAS_TRANSPOSE:
+        CblasNoTrans=111
+        CblasTrans=112
+        CblasConjTrans=113
+    void dgemm 'cblas_dgemm' (
+        CBLAS_ORDER Order, CBLAS_TRANSPOSE TransA,
+        CBLAS_TRANSPOSE TransB, int M, int N,
+        int K, double alpha, double *A, int lda,
+        double *B, int ldb, double beta, double *C, int ldc)
 
 from threadpoolctl import ThreadpoolController
 
@@ -18,11 +31,6 @@ def check_nested_prange_blas(double[:, ::1] A, double[:, ::1] B, int nthreads):
         int n_chunks = 100
         int chunk_size = A.shape[0] // n_chunks
 
-        char* trans = 't'
-        char* no_trans = 'n'
-        double alpha = 1.0
-        double beta = 0.0
-
         int i
         int prange_num_threads
         int *prange_num_threads_ptr = &prange_num_threads
@@ -37,8 +45,8 @@ def check_nested_prange_blas(double[:, ::1] A, double[:, ::1] B, int nthreads):
             prange_num_threads_ptr[0] = openmp.omp_get_num_threads()
 
         for i in prange(n_chunks):
-            dgemm(trans, no_trans, &n, &chunk_size, &k,
-                &alpha, &B[0, 0], &k, &A[i * chunk_size, 0], &k,
-                &beta, &C[i * chunk_size, 0], &n)
+            dgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
+            chunk_size, n, k, alpha, &A[i * chunk_size, 0], k,
+            &B[0, 0], k, beta, &C[i * chunk_size, 0], n)
 
     return np.asarray(C), prange_num_threads, inner_info[0]

--- a/tests/_openmp_test_helper/setup_nested_prange_blas.py
+++ b/tests/_openmp_test_helper/setup_nested_prange_blas.py
@@ -14,11 +14,13 @@ try:
 
     use_blis = os.getenv("INSTALL_BLIS", False)
     libraries = ["blis"] if use_blis else []
+    blis_suffix = "_blis" if use_blis else ""
+    filename = f"nested_prange_blas{blis_suffix}.pyx"
 
     ext_modules = [
         Extension(
             "nested_prange_blas",
-            ["nested_prange_blas.pyx"],
+            [filename],
             extra_compile_args=openmp_flag,
             extra_link_args=openmp_flag,
             libraries=libraries,
@@ -29,7 +31,6 @@ try:
         name="_openmp_test_helper_nested_prange_blas",
         ext_modules=cythonize(
             ext_modules,
-            compile_time_env={"USE_BLIS": use_blis},
             compiler_directives={
                 "language_level": 3,
                 "boundscheck": False,


### PR DESCRIPTION
cython `IF` / `ELSE` are deprecated. I didn't find a easy solution to remove them without splitting into 2 separate files: one when using BLIS and one when not.