### PR TITLE
Python 3.12 version support and make tests tolerate the presence of OpenMP for system Python

### DIFF
--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -25,7 +25,7 @@ stages:
     steps:
       - task: UsePythonVersion@0
         inputs:
-          versionSpec: '3.11'
+          versionSpec: '3.12'
       - script: |
           pip install black
         displayName: install black
@@ -39,18 +39,18 @@ stages:
       vmImage: windows-latest
       matrix:
         pylatest_conda_forge_mkl:
-          VERSION_PYTHON: '*'
+          PYTHON_VERSION: '*'
           PACKAGER: 'conda-forge'
           BLAS: 'mkl'
         py310_conda_forge_openblas:
-          VERSION_PYTHON: '3.10'
+          PYTHON_VERSION: '3.10'
           PACKAGER: 'conda-forge'
           BLAS: 'openblas'
         py39_conda:
-          VERSION_PYTHON: '3.9'
+          PYTHON_VERSION: '3.9'
           PACKAGER: 'conda'
         py38_pip:
-          VERSION_PYTHON: '3.8'
+          PYTHON_VERSION: '3.8'
           PACKAGER: 'pip'
 
 
@@ -64,19 +64,19 @@ stages:
         py38_ubuntu_atlas_gcc_gcc:
           PACKAGER: 'ubuntu'
           APT_BLAS: 'libatlas3-base libatlas-base-dev'
-          VERSION_PYTHON: '3.8'
+          PYTHON_VERSION: '3.8'
           CC_OUTER_LOOP: 'gcc'
           CC_INNER_LOOP: 'gcc'
         py38_ubuntu_openblas_gcc_gcc:
           PACKAGER: 'ubuntu'
           APT_BLAS: 'libopenblas-base libopenblas-dev'
-          VERSION_PYTHON: '3.8'
+          PYTHON_VERSION: '3.8'
           CC_OUTER_LOOP: 'gcc'
           CC_INNER_LOOP: 'gcc'
         # Linux + Python 3.9 and homogeneous runtime nesting.
         py39_conda_openblas_clang_clang:
           PACKAGER: 'conda'
-          VERSION_PYTHON: '3.9'
+          PYTHON_VERSION: '3.9'
           BLAS: 'openblas'
           CC_OUTER_LOOP: 'clang-10'
           CC_INNER_LOOP: 'clang-10'
@@ -84,7 +84,7 @@ stages:
         # threadpoolctl) to only test the warning from multiple OpenMP.
         pylatest_conda_mkl_clang_gcc:
           PACKAGER: 'conda'
-          VERSION_PYTHON: '*'
+          PYTHON_VERSION: '*'
           BLAS: 'mkl'
           CC_OUTER_LOOP: 'clang-10'
           CC_INNER_LOOP: 'gcc'
@@ -92,7 +92,7 @@ stages:
         # Linux environment with MKL, safe for threadpoolctl.
         pylatest_conda_mkl_gcc_gcc:
           PACKAGER: 'conda'
-          VERSION_PYTHON: '*'
+          PYTHON_VERSION: '*'
           BLAS: 'mkl'
           CC_OUTER_LOOP: 'gcc'
           CC_INNER_LOOP: 'gcc'
@@ -101,13 +101,13 @@ stages:
         # and heterogeneous OpenMP runtimes.
         py38_pip_openblas_gcc_clang:
           PACKAGER: 'pip'
-          VERSION_PYTHON: '3.8'
+          PYTHON_VERSION: '3.8'
           CC_OUTER_LOOP: 'gcc'
           CC_INNER_LOOP: 'clang-10'
         # Linux environment with numpy from conda-forge channel and openblas-openmp
         pylatest_conda_forge:
           PACKAGER: 'conda-forge'
-          VERSION_PYTHON: '*'
+          PYTHON_VERSION: '*'
           BLAS: 'openblas'
           OPENBLAS_THREADING_LAYER: 'openmp'
           CC_OUTER_LOOP: 'gcc'
@@ -116,13 +116,13 @@ stages:
         pylatest_conda_nonumpy_gcc_clang:
           PACKAGER: 'conda'
           NO_NUMPY: 'true'
-          VERSION_PYTHON: '*'
+          PYTHON_VERSION: '*'
           CC_OUTER_LOOP: 'gcc'
           CC_INNER_LOOP: 'clang-10'
         # Linux environment with numpy linked to BLIS
         pylatest_blis_gcc_clang_openmp:
           PACKAGER: 'conda'
-          VERSION_PYTHON: '*'
+          PYTHON_VERSION: '*'
           INSTALL_BLIS: 'true'
           BLIS_NUM_THREADS: '4'
           CC_OUTER_LOOP: 'gcc'
@@ -131,7 +131,7 @@ stages:
           BLIS_ENABLE_THREADING: 'openmp'
         pylatest_blis_clang_gcc_pthreads:
           PACKAGER: 'conda'
-          VERSION_PYTHON: '*'
+          PYTHON_VERSION: '*'
           INSTALL_BLIS: 'true'
           BLIS_NUM_THREADS: '4'
           CC_OUTER_LOOP: 'clang-10'
@@ -140,7 +140,7 @@ stages:
           BLIS_ENABLE_THREADING: 'pthreads'
         pylatest_blis_no_threading:
           PACKAGER: 'conda'
-          VERSION_PYTHON: '*'
+          PYTHON_VERSION: '*'
           INSTALL_BLIS: 'true'
           BLIS_NUM_THREADS: '1'
           CC_OUTER_LOOP: 'gcc'
@@ -156,7 +156,7 @@ stages:
         # MacOS environment with OpenMP installed through homebrew
         py38_conda_homebrew_libomp:
           PACKAGER: 'conda'
-          VERSION_PYTHON: '3.8'
+          PYTHON_VERSION: '3.8'
           BLAS: 'openblas'
           CC_OUTER_LOOP: 'clang'
           CC_INNER_LOOP: 'clang'
@@ -164,7 +164,7 @@ stages:
         # MacOS env with OpenBLAS and OpenMP installed through conda-forge compilers
         py39_conda_forge_clang_openblas:
           PACKAGER: 'conda-forge'
-          VERSION_PYTHON: '*'
+          PYTHON_VERSION: '*'
           BLAS: 'openblas'
           CC_OUTER_LOOP: 'clang'
           CC_INNER_LOOP: 'clang'
@@ -172,7 +172,7 @@ stages:
         # MacOS environment with OpenMP installed through conda-forge compilers
         pylatest_conda_forge_clang:
           PACKAGER: 'conda-forge'
-          VERSION_PYTHON: '*'
+          PYTHON_VERSION: '*'
           BLAS: 'mkl'
           CC_OUTER_LOOP: 'clang'
           CC_INNER_LOOP: 'clang'

--- a/continuous_integration/install.cmd
+++ b/continuous_integration/install.cmd
@@ -10,7 +10,7 @@ set PIP_INSTALL=pip install -q
 call deactivate
 @rem Clean up any left-over from a previous build and install version of python
 conda remove --all -q -y -n %VIRTUALENV%
-conda create -n %VIRTUALENV% -q -y python=%VERSION_PYTHON%
+conda create -n %VIRTUALENV% -q -y python=%PYTHON_VERSION%
 
 call activate %VIRTUALENV%
 python -m pip install -U pip

--- a/continuous_integration/install.cmd
+++ b/continuous_integration/install.cmd
@@ -9,6 +9,8 @@ set PIP_INSTALL=pip install -q
 @rem Deactivate any environment
 call deactivate
 @rem Clean up any left-over from a previous build and install version of python
+conda update -n base conda conda-libmamba-solver -q -y
+conda config --set solver libmamba
 conda remove --all -q -y -n %VIRTUALENV%
 conda create -n %VIRTUALENV% -q -y python=%PYTHON_VERSION%
 

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -16,8 +16,9 @@ make_conda() {
     TO_INSTALL="$@"
     if [[ "$UNAMESTR" == "Darwin" ]]; then
         if [[ "$INSTALL_LIBOMP" == "conda-forge" ]]; then
+            conda install -n base conda conda-libmamba-solver --yes
+            conda config --set solver libmamba
             # Install an OpenMP-enabled clang/llvm from conda-forge
-
             # assumes conda-forge is set on priority channel
             TO_INSTALL="$TO_INSTALL compilers llvm-openmp"
 

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -40,7 +40,7 @@ make_conda() {
 }
 
 if [[ "$PACKAGER" == "conda" ]]; then
-    TO_INSTALL="python=$VERSION_PYTHON pip"
+    TO_INSTALL="python=$PYTHON_VERSION pip"
     if [[ "$NO_NUMPY" != "true" ]]; then
         TO_INSTALL="$TO_INSTALL numpy scipy blas[build=$BLAS]"
     fi
@@ -49,7 +49,7 @@ if [[ "$PACKAGER" == "conda" ]]; then
 elif [[ "$PACKAGER" == "conda-forge" ]]; then
     conda config --prepend channels conda-forge
     conda config --set channel_priority strict
-    TO_INSTALL="python=$VERSION_PYTHON numpy scipy blas[build=$BLAS]"
+    TO_INSTALL="python=$PYTHON_VERSION numpy scipy blas[build=$BLAS]"
     if [[ "$BLAS" == "openblas" && "$OPENBLAS_THREADING_LAYER" == "openmp" ]]; then
         TO_INSTALL="$TO_INSTALL libopenblas=*=*openmp*"
     fi
@@ -58,7 +58,7 @@ elif [[ "$PACKAGER" == "conda-forge" ]]; then
 elif [[ "$PACKAGER" == "pip" ]]; then
     # Use conda to build an empty python env and then use pip to install
     # numpy and scipy
-    TO_INSTALL="python=$VERSION_PYTHON pip"
+    TO_INSTALL="python=$PYTHON_VERSION pip"
     make_conda $TO_INSTALL
     if [[ "$NO_NUMPY" != "true" ]]; then
         pip install numpy scipy

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -34,7 +34,7 @@ make_conda() {
             export LDFLAGS="$LDFLAGS -Wl,-rpath,/usr/local/opt/libomp/lib -L/usr/local/opt/libomp/lib -lomp"
         fi
     fi
-    conda install -n base conda conda-libmamba-solver --yes
+    conda update -n base conda conda-libmamba-solver -q --yes
     conda config --set solver libmamba
     conda create -n $VIRTUALENV -q --yes $TO_INSTALL
     source activate $VIRTUALENV

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -16,8 +16,6 @@ make_conda() {
     TO_INSTALL="$@"
     if [[ "$UNAMESTR" == "Darwin" ]]; then
         if [[ "$INSTALL_LIBOMP" == "conda-forge" ]]; then
-            conda install -n base conda conda-libmamba-solver --yes
-            conda config --set solver libmamba
             # Install an OpenMP-enabled clang/llvm from conda-forge
             # assumes conda-forge is set on priority channel
             TO_INSTALL="$TO_INSTALL compilers llvm-openmp"
@@ -36,6 +34,8 @@ make_conda() {
             export LDFLAGS="$LDFLAGS -Wl,-rpath,/usr/local/opt/libomp/lib -L/usr/local/opt/libomp/lib -lomp"
         fi
     fi
+    conda install -n base conda conda-libmamba-solver --yes
+    conda config --set solver libmamba
     conda create -n $VIRTUALENV -q --yes $TO_INSTALL
     source activate $VIRTUALENV
 }

--- a/continuous_integration/install_with_blis.sh
+++ b/continuous_integration/install_with_blis.sh
@@ -13,6 +13,8 @@ sudo ./llvm.sh 10
 sudo apt-get install libomp-dev
 
 # create conda env
+conda update -n base conda conda-libmamba-solver -q --yes
+conda config --set solver libmamba
 conda create -n $VIRTUALENV -q --yes -c conda-forge python=$PYTHON_VERSION pip cython
 source activate $VIRTUALENV
 

--- a/continuous_integration/install_with_blis.sh
+++ b/continuous_integration/install_with_blis.sh
@@ -13,7 +13,7 @@ sudo ./llvm.sh 10
 sudo apt-get install libomp-dev
 
 # create conda env
-conda create -n $VIRTUALENV -q --yes -c conda-forge python=$VERSION_PYTHON pip cython
+conda create -n $VIRTUALENV -q --yes -c conda-forge python=$PYTHON_VERSION pip cython
 source activate $VIRTUALENV
 
 if [[ "$BLIS_CC" == "gcc-8" ]]; then

--- a/continuous_integration/test_script.cmd
+++ b/continuous_integration/test_script.cmd
@@ -1,5 +1,8 @@
 call activate %VIRTUALENV%
 
+# Display version information
+python -m pip list
+
 # Use the CLI to display the effective runtime environment prior to
 # launching the tests:
 python -m threadpoolctl -i numpy scipy.linalg tests._openmp_test_helper.openmp_helpers_inner

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -4,11 +4,14 @@ set -e
 
 if [[ "$PACKAGER" == conda* ]]; then
     source activate $VIRTUALENV
+    conda list
 elif [[ "$PACKAGER" == "pip" ]]; then
     # we actually use conda to install the base environment:
     source activate $VIRTUALENV
+    pip list
 elif [[ "$PACKAGER" == "ubuntu" ]]; then
     source $VIRTUALENV/bin/activate
+    pip list
 fi
 
 set -x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,11 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
 [tool.black]
 line-length = 88
-target_version = ['py38', 'py39', 'py310', 'py311']
+target_version = ['py38', 'py39', 'py310', 'py311', 'py312']
 preview = true

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -557,14 +557,7 @@ def test_command_line_empty_or_system_openmp():
     if not managed_by_conda:  # pragma: no cover
         # When using a Python interpreter that is not the one from the conda
         # environment, we should ignore any system OpenMP library.
-        results = [
-            library
-            for library in results
-            if not (
-                library["filepath"].startswith("/usr/lib/")
-                and library["user_api"] == "openmp"
-            )
-        ]
+        results = [r for r in results if r["user_api"] != "openmp"]
     assert results == []
 
 

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -545,9 +545,27 @@ def test_libomp_libiomp_warning(recwarn):
     assert "multiple_openmp.md" in str(wm.message)
 
 
-def test_command_line_empty():
+def test_command_line_empty_or_system_openmp():
+    # When the command line is called without arguments, no library should be
+    # detected. The only exception is a system OpenMP library that can be
+    # linked to the Python interpreter, for instance via the libb2.so BLAKE2
+    # library that can itself be linked to an OpenMP runtime on Gentoo.
     output = subprocess.check_output((sys.executable + " -m threadpoolctl").split())
-    assert json.loads(output.decode("utf-8")) == []
+    results = json.loads(output.decode("utf-8"))
+    conda_prefix = os.getenv("CONDA_PREFIX")
+    managed_by_conda = conda_prefix and sys.executable.startswith(conda_prefix)
+    if not managed_by_conda:  # pragma: no cover
+        # When using a Python interpreter that is not the one from the conda
+        # environment, we should ignore any system OpenMP library.
+        results = [
+            library
+            for library in results
+            if not (
+                library["filepath"].startswith("/usr/lib/")
+                and library["user_api"] == "openmp"
+            )
+        ]
+    assert results == []
 
 
 def test_command_line_command_flag():

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -555,7 +555,7 @@ def test_command_line_empty_or_system_openmp():
     conda_prefix = os.getenv("CONDA_PREFIX")
     managed_by_conda = conda_prefix and sys.executable.startswith(conda_prefix)
     if not managed_by_conda:  # pragma: no cover
-        # When using a Python interpreter that is not the one from the conda
+        # When using a Python interpreter that does not come from a conda
         # environment, we should ignore any system OpenMP library.
         results = [r for r in results if r["user_api"] != "openmp"]
     assert results == []


### PR DESCRIPTION
Fixes #146.

Actually our CI does not need any update to test against the latest Python version available on conda-forge.

This PR is mostly about updating `pyproject.toml` and renaming `VERSION_PYTHON` to `PYTHON_VERSION` to sound more correct English.

EDIT: also tolerate the presence of OpenMP when Python is not installed via conda.