### PR TITLE
TST Don't skip test_nested_prange_blas for BLIS

### DIFF
--- a/continuous_integration/install_with_blis.sh
+++ b/continuous_integration/install_with_blis.sh
@@ -53,6 +53,9 @@ python -m pip install -q -r dev-requirements.txt
 CFLAGS=-I$ABS_PATH/BLIS_install/include/blis LDFLAGS=-L$ABS_PATH/BLIS_install/lib \
     bash ./continuous_integration/build_test_ext.sh
 
+# Check dynamic linking
+ldd tests/_openmp_test_helper/nested_prange_blas.cpython*.so
+
 python --version
 python -c "import numpy; print(f'numpy {numpy.__version__}')" || echo "no numpy"
 python -c "import scipy; print(f'scipy {scipy.__version__}')" || echo "no scipy"

--- a/continuous_integration/install_with_blis.sh
+++ b/continuous_integration/install_with_blis.sh
@@ -50,7 +50,8 @@ popd
 popd
 
 python -m pip install -q -r dev-requirements.txt
-CFLAGS=-I$ABS_PATH/BLIS_install/include/blis LDFLAGS=-L$ABS_PATH/BLIS_install/lib \
+CFLAGS=-I$ABS_PATH/BLIS_install/include/blis \
+    LDFLAGS="-L$ABS_PATH/BLIS_install/lib -Wl,-rpath,$ABS_PATH/BLIS_install/lib" \
     bash ./continuous_integration/build_test_ext.sh
 
 # Check dynamic linking

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -414,7 +414,7 @@ def test_nested_prange_blas(nthreads_outer):
     # Check that the BLAS uses the number of threads requested by the context manager
     # when nested in an outer OpenMP loop.
     # Remark: this test also works with sequential BLAS only because we limit the
-    # number of threads for the BLAS to 1.
+    # number of threads for the BLAS to 1.
     np = pytest.importorskip("numpy")
     prange_blas = pytest.importorskip("tests._openmp_test_helper.nested_prange_blas")
     check_nested_prange_blas = prange_blas.check_nested_prange_blas

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -411,18 +411,17 @@ def test_multiple_shipped_openblas():
 )
 @pytest.mark.parametrize("nthreads_outer", [None, 1, 2, 4])
 def test_nested_prange_blas(nthreads_outer):
-    # Check that the BLAS linked to scipy effectively uses the number of
-    # threads requested by the context manager when nested in an outer OpenMP
-    # loop.
-    # np = pytest.importorskip("numpy")
+    # Check that the BLAS uses the number of threads requested by the context manager
+    # when nested in an outer OpenMP loop.
+    # Remark: this test also works with sequential BLAS only because we limit the
+    # number of threads for the BLAS to 1.
+    np = pytest.importorskip("numpy")
     prange_blas = pytest.importorskip("tests._openmp_test_helper.nested_prange_blas")
     check_nested_prange_blas = prange_blas.check_nested_prange_blas
 
     skip_if_openblas_openmp()
 
     original_info = ThreadpoolController().info()
-
-    print(original_info)
 
     blas_controller = ThreadpoolController().select(user_api="blas")
     blis_controller = ThreadpoolController().select(internal_api="blis")
@@ -456,8 +455,6 @@ def test_nested_prange_blas(nthreads_outer):
     assert all(lib_info["num_threads"] == 1 for lib_info in nested_blas_info)
 
     assert ThreadpoolController().info() == original_info
-
-    assert False
 
 
 # the method `get_original_num_threads` raises a UserWarning due to different

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -414,8 +414,7 @@ def test_nested_prange_blas(nthreads_outer):
     # Check that the BLAS linked to scipy effectively uses the number of
     # threads requested by the context manager when nested in an outer OpenMP
     # loop.
-    import numpy as np
-
+    np = pytest.importorskip("numpy")
     prange_blas = pytest.importorskip("tests._openmp_test_helper.nested_prange_blas")
     check_nested_prange_blas = prange_blas.check_nested_prange_blas
 

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -414,7 +414,7 @@ def test_nested_prange_blas(nthreads_outer):
     # Check that the BLAS linked to scipy effectively uses the number of
     # threads requested by the context manager when nested in an outer OpenMP
     # loop.
-    np = pytest.importorskip("numpy")
+    # np = pytest.importorskip("numpy")
     prange_blas = pytest.importorskip("tests._openmp_test_helper.nested_prange_blas")
     check_nested_prange_blas = prange_blas.check_nested_prange_blas
 

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -415,10 +415,8 @@ def test_nested_prange_blas(nthreads_outer):
     # threads requested by the context manager when nested in an outer OpenMP
     # loop.
     import numpy as np
-    prange_blas = pytest.importorskip(
-        "tests._openmp_test_helper.nested_prange_blas"
-    )
 
+    prange_blas = pytest.importorskip("tests._openmp_test_helper.nested_prange_blas")
     check_nested_prange_blas = prange_blas.check_nested_prange_blas
 
     skip_if_openblas_openmp()

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -406,7 +406,6 @@ def test_multiple_shipped_openblas():
     test_shipped_openblas()
 
 
-@pytest.mark.skipif(scipy is None, reason="requires scipy")
 @pytest.mark.skipif(
     not cython_extensions_compiled, reason="Requires cython extensions to be compiled"
 )
@@ -416,7 +415,9 @@ def test_nested_prange_blas(nthreads_outer):
     # threads requested by the context manager when nested in an outer OpenMP
     # loop.
     import numpy as np
-    import tests._openmp_test_helper.nested_prange_blas as prange_blas
+    prange_blas = pytest.importorskip(
+        "tests._openmp_test_helper.nested_prange_blas"
+    )
 
     check_nested_prange_blas = prange_blas.check_nested_prange_blas
 

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -422,6 +422,8 @@ def test_nested_prange_blas(nthreads_outer):
 
     original_info = ThreadpoolController().info()
 
+    print(original_info)
+
     blas_controller = ThreadpoolController().select(user_api="blas")
     blis_controller = ThreadpoolController().select(internal_api="blis")
 
@@ -454,6 +456,8 @@ def test_nested_prange_blas(nthreads_outer):
     assert all(lib_info["num_threads"] == 1 for lib_info in nested_blas_info)
 
     assert ThreadpoolController().info() == original_info
+
+    assert False
 
 
 # the method `get_original_num_threads` raises a UserWarning due to different

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -4,6 +4,7 @@ This module provides utilities to introspect native libraries that relies on
 thread pools (notably BLAS and OpenMP implementations) and dynamically set the
 maximal number of threads they can use.
 """
+
 # License: BSD 3-Clause
 
 # The code to introspect dynamically loaded libraries on POSIX systems is


### PR DESCRIPTION
`test_nested_prange_blas` was not running in jobs using BLIS because they have no scipy. But scipy is not required to run this test in that case.

I enabled the test for BLIS and to my surprised it worked. I expected otherwise because I found an issue in the linker flags used to compile the extensions for the tests. It was missing a flag to hard code the library path in the dso. Without that the dynamic linker can't find it at runtime (confirmed with a newly added `ldd` check). It turns out that since we import numpy and that numpy is appropriately linked to BLIS, the dynamic linker is somehow able to find it anyway.