### PR TITLE
TST noexcept is no longer the default

### DIFF
--- a/tests/_openmp_test_helper/openmp_helpers_inner.pxd
+++ b/tests/_openmp_test_helper/openmp_helpers_inner.pxd
@@ -1,1 +1,1 @@
-cdef int inner_openmp_loop(int) nogil
+cdef int inner_openmp_loop(int) noexcept nogil

--- a/tests/_openmp_test_helper/openmp_helpers_inner.pyx
+++ b/tests/_openmp_test_helper/openmp_helpers_inner.pyx
@@ -15,7 +15,7 @@ def check_openmp_num_threads(int n):
     return num_threads
 
 
-cdef int inner_openmp_loop(int n) nogil:
+cdef int inner_openmp_loop(int n) noexcept nogil:
     """Run a short parallel section with OpenMP
 
     Return the number of threads that where effectively used by the

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -4,6 +4,7 @@ This module provides utilities to introspect native libraries that relies on
 thread pools (notably BLAS and OpenMP implementations) and dynamically set the
 maximal number of threads they can use.
 """
+
 # License: BSD 3-Clause
 
 # The code to introspect dynamically loaded libraries on POSIX systems is


### PR DESCRIPTION
Saw this warning in compilation log:
```
Exception check will always require the GIL to be acquired. Declare the function as 'noexcept'
if you control the definition and you're sure you don't want the function to raise exceptions.
```