### PR TITLE
FEA Support static and / or alternative libc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 3.4.0 (TDB)
 ===========
 
+- Added support for Python interpreters statically linked against libc or linked against
+  alternative implementations of libc like musl (on Alpine Linux for instance).
+  https://github.com/joblib/threadpoolctl/pull/171
+
 - Added support for Pyodide
   https://github.com/joblib/threadpoolctl/pull/169
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -1219,16 +1219,13 @@ class ThreadpoolController:
         """Load the lib-C for unix systems."""
         libc = cls._system_libraries.get("libc")
         if libc is None:
-            libc_name = find_library("c")
-            if libc_name is None:  # pragma: no cover
-                warnings.warn(
-                    "libc not found. The ctypes module in Python"
-                    f" {sys.version_info.major}.{sys.version_info.minor} is maybe"
-                    " too old for this OS.",
-                    RuntimeWarning,
-                )
-                return None
-            libc = ctypes.CDLL(libc_name, mode=_RTLD_NOLOAD)
+            # Remark: If libc is statically linked or if Python is linked against an
+            # alternative implementation of libc like musl, find_library will return
+            # None and CDLL will load the main program itself which should contain the
+            # libc symbols. We still name it libc for convenience.
+            # If the main program does not contain the libc symbols, it's ok because
+            # we check their presence later anyway.
+            libc = ctypes.CDLL(find_library("c"), mode=_RTLD_NOLOAD)
             cls._system_libraries["libc"] = libc
         return libc
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -996,6 +996,10 @@ class ThreadpoolController:
         """
         libc = self._get_libc()
         if not hasattr(libc, "dl_iterate_phdr"):  # pragma: no cover
+            warnings.warn(
+                "Could not find dl_iterate_phdr in the C standard library.",
+                RuntimeWarning,
+            )
             return []
 
         # Callback function for `dl_iterate_phdr` which is called for every
@@ -1028,6 +1032,10 @@ class ThreadpoolController:
         """
         libc = self._get_libc()
         if not hasattr(libc, "_dyld_image_count"):  # pragma: no cover
+            warnings.warn(
+                "Could not find _dyld_image_count in the C standard library.",
+                RuntimeWarning,
+            )
             return []
 
         n_dyld = libc._dyld_image_count()


### PR DESCRIPTION
Fixes https://github.com/joblib/threadpoolctl/issues/170

When libc is statically linked or when Python is linked against an alternative implementation of libc, `find_library("c")` won't find anything and we used to raise a misleading warning in that case plus `threadpool_info` would have an empty output.

It turns out that `CDLL(None)` follows the convention of `dlopen(NULL)` and loads the main program. This is convenient because the libc symbols we're looking for will be available from the main program in the kind of situation described above.