### PR TITLE
FEA Controller for scipy_openblas

### DIFF
--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -58,6 +58,12 @@ stages:
       name: Linux
       vmImage: ubuntu-20.04
       matrix:
+        # Linux environment with development versions of numpy and scipy
+        pylatest_pip_dev:
+          PACKAGER: 'pip-dev'
+          PYTHON_VERSION: '*'
+          CC_OUTER_LOOP: 'gcc'
+          CC_INNER_LOOP: 'gcc'
         # Linux environment to test that packages that comes with Ubuntu 20.04
         # are correctly handled.
         py38_ubuntu_atlas_gcc_gcc:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+3.5.0 (TDB)
+===========
+
+- Added support for the Scientific Python version of OpenBLAS
+  (https://github.com/MacPython/openblas-libs), which exposes symbols with different
+  names than the ones of the original OpenBLAS library.
+  https://github.com/joblib/threadpoolctl/pull/175
+
 3.4.0 (2024-03-20)
 ==================
 

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -65,6 +65,15 @@ elif [[ "$PACKAGER" == "pip" ]]; then
         pip install numpy scipy
     fi
 
+elif [[ "$PACKAGER" == "pip-dev" ]]; then
+    # Use conda to build an empty python env and then use pip to install
+    # numpy and scipy dev versions
+    TO_INSTALL="python=$PYTHON_VERSION pip"
+    make_conda $TO_INSTALL
+
+    dev_anaconda_url=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy scipy
+
 elif [[ "$PACKAGER" == "ubuntu" ]]; then
     # Remove the ubuntu toolchain PPA that seems to be invalid:
     # https://github.com/scikit-learn/scikit-learn/pull/13934

--- a/continuous_integration/posix.yml
+++ b/continuous_integration/posix.yml
@@ -14,7 +14,7 @@ jobs:
   steps:
     - bash: echo "##vso[task.prependpath]$CONDA/bin"
       displayName: Add conda to PATH
-      condition: or(startsWith(variables['PACKAGER'], 'conda'), eq(variables['PACKAGER'], 'pip'))
+      condition: or(startsWith(variables['PACKAGER'], 'conda'), startsWith(variables['PACKAGER'], 'pip'))
     - bash: sudo chown -R $USER $CONDA
       # On Hosted macOS, the agent user doesn't have ownership of Miniconda's installation directory/
       # We need to take ownership if we want to update conda or install packages globally

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -5,7 +5,7 @@ set -e
 if [[ "$PACKAGER" == conda* ]]; then
     source activate $VIRTUALENV
     conda list
-elif [[ "$PACKAGER" == "pip" ]]; then
+elif [[ "$PACKAGER" == pip* ]]; then
     # we actually use conda to install the base environment:
     source activate $VIRTUALENV
     pip list

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -118,16 +118,13 @@ class LibController(ABC):
 
     def info(self):
         """Return relevant info wrapped in a dict"""
-        exposed_attrs = {
+        hidden_attrs = ("dynlib", "parent", "_symbol_prefix", "_symbol_suffix")
+        return {
             "user_api": self.user_api,
             "internal_api": self.internal_api,
             "num_threads": self.num_threads,
-            # Include all attributes that are not private
-            **{k: v for k, v in vars(self).items() if not k.startswith("_")},
+            **{k: v for k, v in vars(self).items() if k not in hidden_attrs},
         }
-        exposed_attrs.pop("dynlib")
-        exposed_attrs.pop("parent")
-        return exposed_attrs
 
     def set_additional_attributes(self):
         """Set additional attributes meant to be exposed in the info dict"""

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -125,7 +125,8 @@ class LibController(ABC):
             "internal_api": self.internal_api,
             "num_threads": self.num_threads,
             # Include all attributes that are not private
-            **{k: v for k, v in vars(self).items() if not k.startswith("_")},
+            # **{k: v for k, v in vars(self).items() if not k.startswith("_")},
+            **vars(self),
         }
         exposed_attrs.pop("dynlib")
         exposed_attrs.pop("parent")
@@ -205,6 +206,7 @@ class OpenBLASController(LibController):
 
     def set_num_threads(self, num_threads):
         if (symbol := self._get_symbol("openblas_set_num_threads")) is not None:
+            print(symbol)
             return symbol(num_threads)
         return None
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -254,7 +254,9 @@ class OpenBLASController(LibController):
         return get_corename().decode("utf-8")
 
 
-class ScipyOpenBLASController(OpenBLASController):
+class SciPyOpenBLASController(OpenBLASController):
+    """Controller class for SciPy OpenBLAS"""
+
     filename_prefixes = ("libscipy_openblas", "libblas")
     check_symbols = (
         "scipy_openblas_get_num_threads",
@@ -546,7 +548,7 @@ class OpenMPController(LibController):
 # Third party libraries can register their own controllers.
 _ALL_CONTROLLERS = [
     OpenBLASController,
-    ScipyOpenBLASController,
+    SciPyOpenBLASController,
     BLISController,
     MKLController,
     OpenMPController,


### PR DESCRIPTION
Numpy, Scipy, ... will likely be linked against a common build of OpenBLAS for the sci-py ecosystem (https://github.com/MacPython/openblas-libs). At some point it might even become a runtime dependency for these packages.

This special build of OpenBLAS comes with a different naming pattern than OpenBLAS, the lib name being `libscipy_openblas...`, andthe symbols being prefixed by `scipy_`. I made a new controller inherited from the OpenBLAS controller.

I also added a build in the CI to test against the dev versions of numpy and scipy. It would probably have allowed us to face the issue earlier.