### PR TITLE
CI Bump deprecated macos image

### DIFF
--- a/.azure_pipeline.yml
+++ b/.azure_pipeline.yml
@@ -164,7 +164,7 @@ stages:
   - template: continuous_integration/posix.yml
     parameters:
       name: macOS
-      vmImage: macOS-11
+      vmImage: macOS-latest
       matrix:
         # MacOS environment with OpenMP installed through homebrew
         py38_conda_homebrew_libomp:


### PR DESCRIPTION
```
This is a scheduled macOS-11 brownout. The macOS-11 environment is
deprecated and will be removed on June 28th, 2024.
```
Let's try latest