### PR TITLE
ENH Support path length > MAX_PATH on Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 3.6.0 (TBD)
 ===========
 
+- Added support for libraries with a path longer than 260 on Windows. The supported path
+  length is now 10 times higher but not unlimited for security reasons.
+
 - Dropped official support for Python 3.8.
   https://github.com/joblib/threadpoolctl/pull/186
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 
 - Added support for libraries with a path longer than 260 on Windows. The supported path
   length is now 10 times higher but not unlimited for security reasons.
+  https://github.com/joblib/threadpoolctl/pull/189
 
 - Dropped official support for Python 3.8.
   https://github.com/joblib/threadpoolctl/pull/186


### PR DESCRIPTION
Closes https://github.com/joblib/threadpoolctl/issues/181

- limit extended to 10 * MAX_PATH (2600)
- kept a hard limit for security reasons
- A warning is raised if a library has a path too long, and this lib is ignored