### PR TITLE
MNT Drop Python 3.8 support follow-up

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 
 - Dropped official support for Python 3.8.
   https://github.com/joblib/threadpoolctl/pull/186
+  https://github.com/joblib/threadpoolctl/pull/191
 
 3.5.0 (2024-04-29)
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,21 +10,21 @@ author = "Thomas Moreau"
 author-email = "thomas.moreau.2010@gmail.com"
 home-page = "https://github.com/joblib/threadpoolctl"
 description-file = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "BSD-3-Clause"
 classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
 [tool.black]
 line-length = 88
-target_version = ['py38', 'py39', 'py310', 'py311', 'py312']
+target_version = ['py39', 'py310', 'py311', 'py312', 'py313']
 preview = true


### PR DESCRIPTION
Forgot that in https://github.com/joblib/threadpoolctl/pull/186