### PR TITLE
CI Temporary disable tag condition to publish to PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -35,7 +35,8 @@ jobs:
   publish-to-pypi:
     name: >-
       Publish threadpoolctl 🎮 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    # temp: always publish to PyPI because the tag is already pushed
+    # if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     needs:
     - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Because the tag is already there. I'll revert that right after