### PR TITLE
Use `as_py_json` in place of deprecated `as_object_map` for Pyodide>=0.29

### DIFF
--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -1131,12 +1131,11 @@ class ThreadpoolController:
                 "happen."
             )
             return
-        
-        if hasattr(LDSO.loadedLibsByName, 'as_py_json'):  # Pyodide >= 0.29
+
+        if hasattr(LDSO.loadedLibsByName, "as_py_json"):  # Pyodide >= 0.29
             libs_iter = LDSO.loadedLibsByName.as_py_json()
         else:
             libs_iter = LDSO.loadedLibsByName.as_object_map()  # Pyodide < 0.29
-
 
         for filepath in libs_iter:
             # Some libraries are duplicated by Pyodide and do not exist in the


### PR DESCRIPTION
We deprecated this method with Pyodide v0.29, and it will be removed in Pyodide v0.31. See https://github.com/pyodide/pyodide/pull/5010, which adds a replacement that should work out of the box as it supports the `IS_PY_JSON_DICT` flag.

I tested this on the Pyodide dev and stable consoles with a few packages installed; it works well. I'll open a separate issue to discuss whether we want to smoke test Pyodide in-tree here.

cc: @lesteve
xref: https://github.com/scikit-image/scikit-image/pull/7931