### PR TITLE
docs: Correct README claim that OpenMP thread limits are process-wide

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,10 +322,12 @@ https://github.com/xianyi/OpenBLAS/issues/2985).
   and workarounds:
   https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md
 
-- Setting the maximum number of threads of the OpenMP and BLAS libraries has a global
-  effect and impacts the whole Python process. There is no thread level isolation as
-  these libraries do not offer thread-local APIs to configure the number of threads to
-  use in nested parallel calls.
+- Setting the maximum number of threads of BLAS libraries such as OpenBLAS with
+  the pthreads threading layer and MKL has a global effect and impacts the whole
+  Python process. By contrast, for OpenMP runtimes such as libgomp and libomp,
+  `omp_set_num_threads` applies to the calling thread. Therefore, when
+  `threadpool_limits` limits OpenMP libraries, the limit is applied on the
+  current thread and does not propagate to threads spawned afterward.
 
 
 ## Maintainers


### PR DESCRIPTION
## Summary
The README's 'Limitations' section states that setting the maximum number of threads for OpenMP and BLAS libraries 'has a global effect and impacts the whole Python process' and that 'there is no thread level isolation as these libraries do not offer thread-local APIs.' Issue author itamarst demonstrated with reproducible programs (libgomp on Ubuntu, libomp via Conda-Forge) that OpenMP limits are in fact thread-specific: a limit set on the main thread does not affect a newly spawned thread's OpenMP thread count, while BLAS/OpenBLAS pthreads limits do remain process-wide. Maintainer ogrisel confirmed on 2026-06-17 that 'the documentation is wrong' and explicitly invited a PR for the fix.

Fixes #207
