### PR TITLE
Thread limit introspection API, part 1: API scope

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,10 @@
 3.7.0 (TBD)
 ===========
 
-- Added the ability to check whether a limiting API
-  affects just the current thread or the whole process. Mainly aimed at debugging and diagnostics, and somewhat unreliable, it is therefore enabled by default only for command-line usage.
+- Added the ability to check whether a limiting API affects just the current
+  thread or the whole process. Mainly aimed at debugging and diagnostics, and
+  somewhat unreliable, it is therefore enabled by default only for command-line
+  usage.
   https://github.com/joblib/threadpoolctl/pull/213
 
 - Only warn about simultaneous `libomp` and `libiomp` usage on Linux, where the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+Unreleased
+==============
+
+- Added the ability to check whether a limiting API
+  affects just the current thread or the whole process. Mainly aimed at debugging and diagnostics, and somewhat unreliable, it is therefore enabled by default only for command-line usage.
+  https://github.com/joblib/threadpoolctl/pull/213
+
 3.6.0 (2025-03-13)
 ==================
 

--- a/tests/test_api_introspection.py
+++ b/tests/test_api_introspection.py
@@ -38,7 +38,7 @@ def test_determine_api_scope_thread_local():
     thread-local implementation.
     """
     api = FakeThreadLocalAPI()
-    assert _determine_api_scope(api.get, api.set) == _APIScope.THREAD_LOCAL
+    assert _determine_api_scope(api.get, api.set) == _APIScope.CURRENT_THREAD
 
 
 @pytest.mark.parametrize("default", [1, 17])
@@ -48,4 +48,4 @@ def test_determine_api_scope_processiwde(default: int):
     process-wide implementation.
     """
     api = FakeProcesswideAPI(default)
-    assert _determine_api_scope(api.get, api.set) == _APIScope.PROCESSWIDE
+    assert _determine_api_scope(api.get, api.set) == _APIScope.PROCESS

--- a/tests/test_api_introspection.py
+++ b/tests/test_api_introspection.py
@@ -2,11 +2,19 @@
 Tests for get/set number of threads API introspection.
 """
 
+import sys
 from threading import local as threadlocal
 
 import pytest
 
-from threadpoolctl import _ThreadLimitScope, _determine_thread_limit_scope
+from threadpoolctl import (
+    _ThreadLimitScope,
+    _determine_thread_limit_scope,
+    ThreadpoolController,
+)
+
+# Make sure we have some BLAS libraries loaded:
+from . import utils as _
 
 
 class FakeThreadLocalAPI(threadlocal):
@@ -52,3 +60,38 @@ def test_determine_thread_limit_scope_processwide(default: int) -> None:
     """
     api = FakeProcesswideAPI(default)
     assert _determine_thread_limit_scope(api.get, api.set) == _ThreadLimitScope.PROCESS
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="We only hardcoded Linux-specific behavior"
+)
+@pytest.mark.parametrize(
+    ["select_filter", "expected_thread_limit_scope"],
+    [
+        (
+            {"internal_api": "openblas", "threading_layer": "pthreads"},
+            _ThreadLimitScope.PROCESS,
+        ),
+        (
+            {"user_api": "openmp"},
+            _ThreadLimitScope.CURRENT_THREAD,
+        ),
+    ],
+)
+def test_api_scope(
+    select_filter: dict[str, str], expected_thread_limit_scope: str
+) -> None:
+    """
+    Check ``_determine_thread_limit_scope()`` against libraries with known
+    properties, to make sure it detects them correctly.  The test is intended
+    to be of the function's behavior, not of the libraries.
+    """
+    controller = ThreadpoolController().select(**select_filter)
+    if not controller.lib_controllers:
+        pytest.skip(f"{select_filter} controller not found")
+
+    for lib in controller.lib_controllers:
+        assert (
+            _determine_thread_limit_scope(lib.get_num_threads, lib.set_num_threads)
+            == expected_thread_limit_scope
+        )

--- a/tests/test_api_introspection.py
+++ b/tests/test_api_introspection.py
@@ -6,7 +6,7 @@ from threading import local as threadlocal
 
 import pytest
 
-from threadpoolctl import _APIScope, _determine_api_scope
+from threadpoolctl import _APIScope, _determine_api_scope, ThreadpoolController
 
 
 class FakeThreadLocalAPI(threadlocal):
@@ -44,8 +44,35 @@ def test_determine_api_scope_thread_local():
 @pytest.mark.parametrize("default", [1, 17])
 def test_determine_api_scope_processiwde(default: int):
     """
-    Check ``determine_api_scope()`` can correctly diagnose a trivial
+    Check ``_determine_api_scope()`` can correctly diagnose a trivial
     process-wide implementation.
     """
     api = FakeProcesswideAPI(default)
     assert _determine_api_scope(api.get, api.set) == _APIScope.PROCESS
+
+
+@pytest.mark.parametrize(
+    ["select_filter", "expected_api_scope"],
+    [
+        (
+            {"internal_api": "openblas", "threading_layer": "pthreads"},
+            _APIScope.PROCESS,
+        ),
+        ({"user_api": "openmp", "prefix": "libgomp"}, _APIScope.CURRENT_THREAD),
+        ({"user_api": "openmp", "prefix": "libomp"}, _APIScope.CURRENT_THREAD),
+    ],
+)
+def test_api_scope(select_filter: dict[str, str], expected_api_scope: str) -> None:
+    """
+    Check ``determine_api_scope()`` against known values, to make sure it
+    detects them correctly.
+    """
+    controller = ThreadpoolController().select(**select_filter)
+    if not controller.lib_controllers:
+        pytest.skip(f"{select_filter} controller not found")
+
+    for lib in controller.lib_controllers:
+        assert (
+            _determine_api_scope(lib.get_num_threads, lib.set_num_threads)
+            == expected_api_scope
+        )

--- a/tests/test_api_introspection.py
+++ b/tests/test_api_introspection.py
@@ -9,7 +9,6 @@ import pytest
 from threadpoolctl import _APIScope, _determine_api_scope
 
 
-
 class FakeThreadLocalAPI(threadlocal):
     """Thread-local num threads setting API."""
 

--- a/tests/test_api_introspection.py
+++ b/tests/test_api_introspection.py
@@ -3,9 +3,11 @@ Tests for get/set number of threads API introspection.
 """
 
 from threading import local as threadlocal
-from threadpoolctl import APIScope, determine_api_scope
 
 import pytest
+
+from threadpoolctl import _APIScope, _determine_api_scope
+
 
 
 class FakeThreadLocalAPI(threadlocal):
@@ -33,11 +35,11 @@ class FakeProcesswideAPI:
 
 def test_determine_api_scope_thread_local():
     """
-    Check ``determine_api_scope()`` can correctly diagnose a trivial
+    Check ``_determine_api_scope()`` can correctly diagnose a trivial
     thread-local implementation.
     """
     api = FakeThreadLocalAPI()
-    assert determine_api_scope(api.get, api.set) == APIScope.THREAD_LOCAL
+    assert _determine_api_scope(api.get, api.set) == _APIScope.THREAD_LOCAL
 
 
 @pytest.mark.parametrize("default", [1, 17])
@@ -47,4 +49,4 @@ def test_determine_api_scope_processiwde(default: int):
     process-wide implementation.
     """
     api = FakeProcesswideAPI(default)
-    assert determine_api_scope(api.get, api.set) == APIScope.PROCESSWIDE
+    assert _determine_api_scope(api.get, api.set) == _APIScope.PROCESSWIDE

--- a/tests/test_api_introspection.py
+++ b/tests/test_api_introspection.py
@@ -6,7 +6,7 @@ from threading import local as threadlocal
 
 import pytest
 
-from threadpoolctl import _APIScope, _determine_api_scope, ThreadpoolController
+from threadpoolctl import _APIScope, _determine_api_scope
 
 
 class FakeThreadLocalAPI(threadlocal):
@@ -49,30 +49,3 @@ def test_determine_api_scope_processwide(default: int) -> None:
     """
     api = FakeProcesswideAPI(default)
     assert _determine_api_scope(api.get, api.set) == _APIScope.PROCESS
-
-
-@pytest.mark.parametrize(
-    ["select_filter", "expected_api_scope"],
-    [
-        (
-            {"internal_api": "openblas", "threading_layer": "pthreads"},
-            _APIScope.PROCESS,
-        ),
-        ({"user_api": "openmp", "prefix": "libgomp"}, _APIScope.CURRENT_THREAD),
-        ({"user_api": "openmp", "prefix": "libomp"}, _APIScope.CURRENT_THREAD),
-    ],
-)
-def test_api_scope(select_filter: dict[str, str], expected_api_scope: str) -> None:
-    """
-    Check ``_determine_api_scope()`` against libraries with known properties,
-    to make sure it detects them correctly.
-    """
-    controller = ThreadpoolController().select(**select_filter)
-    if not controller.lib_controllers:
-        pytest.skip(f"{select_filter} controller not found")
-
-    for lib in controller.lib_controllers:
-        assert (
-            _determine_api_scope(lib.get_num_threads, lib.set_num_threads)
-            == expected_api_scope
-        )

--- a/tests/test_api_introspection.py
+++ b/tests/test_api_introspection.py
@@ -32,7 +32,7 @@ class FakeProcesswideAPI:
         self.num_threads = n
 
 
-def test_determine_api_scope_thread_local():
+def test_determine_api_scope_thread_local() -> None:
     """
     Check ``_determine_api_scope()`` can correctly diagnose a trivial
     thread-local implementation.
@@ -42,7 +42,7 @@ def test_determine_api_scope_thread_local():
 
 
 @pytest.mark.parametrize("default", [1, 17])
-def test_determine_api_scope_processiwde(default: int):
+def test_determine_api_scope_processwide(default: int) -> None:
     """
     Check ``_determine_api_scope()`` can correctly diagnose a trivial
     process-wide implementation.
@@ -64,8 +64,8 @@ def test_determine_api_scope_processiwde(default: int):
 )
 def test_api_scope(select_filter: dict[str, str], expected_api_scope: str) -> None:
     """
-    Check ``determine_api_scope()`` against known values, to make sure it
-    detects them correctly.
+    Check ``_determine_api_scope()`` against libraries with known properties,
+    to make sure it detects them correctly.
     """
     controller = ThreadpoolController().select(**select_filter)
     if not controller.lib_controllers:

--- a/tests/test_api_introspection.py
+++ b/tests/test_api_introspection.py
@@ -1,0 +1,50 @@
+"""
+Tests for get/set number of threads API introspection.
+"""
+
+from threading import local as threadlocal
+from threadpoolctl import APIScope, determine_api_scope
+
+import pytest
+
+
+class FakeThreadLocalAPI(threadlocal):
+    """Thread-local num threads setting API."""
+
+    def get(self) -> int:
+        return getattr(self, "num_threads", 17)
+
+    def set(self, n: int) -> None:
+        self.num_threads = n
+
+
+class FakeProcesswideAPI:
+    """Process-wide num threads setting API."""
+
+    def __init__(self, num_threads: int):
+        self.num_threads = num_threads
+
+    def get(self) -> int:
+        return self.num_threads
+
+    def set(self, n: int) -> None:
+        self.num_threads = n
+
+
+def test_determine_api_scope_thread_local():
+    """
+    Check ``determine_api_scope()`` can correctly diagnose a trivial
+    thread-local implementation.
+    """
+    api = FakeThreadLocalAPI()
+    assert determine_api_scope(api.get, api.set) == APIScope.THREAD_LOCAL
+
+
+@pytest.mark.parametrize("default", [1, 17])
+def test_determine_api_scope_processiwde(default: int):
+    """
+    Check ``determine_api_scope()`` can correctly diagnose a trivial
+    process-wide implementation.
+    """
+    api = FakeProcesswideAPI(default)
+    assert determine_api_scope(api.get, api.set) == APIScope.PROCESSWIDE

--- a/tests/test_api_introspection.py
+++ b/tests/test_api_introspection.py
@@ -6,7 +6,7 @@ from threading import local as threadlocal
 
 import pytest
 
-from threadpoolctl import _APIScope, _determine_api_scope
+from threadpoolctl import _ThreadLimitScope, _determine_thread_limit_scope
 
 
 class FakeThreadLocalAPI(threadlocal):
@@ -32,20 +32,23 @@ class FakeProcesswideAPI:
         self.num_threads = n
 
 
-def test_determine_api_scope_thread_local() -> None:
+def test_determine_thread_limit_scope_thread_local() -> None:
     """
-    Check ``_determine_api_scope()`` can correctly diagnose a trivial
+    Check ``_determine_thread_limit_scope()`` can correctly diagnose a trivial
     thread-local implementation.
     """
     api = FakeThreadLocalAPI()
-    assert _determine_api_scope(api.get, api.set) == _APIScope.CURRENT_THREAD
+    assert (
+        _determine_thread_limit_scope(api.get, api.set)
+        == _ThreadLimitScope.CURRENT_THREAD
+    )
 
 
 @pytest.mark.parametrize("default", [1, 17])
-def test_determine_api_scope_processwide(default: int) -> None:
+def test_determine_thread_limit_scope_processwide(default: int) -> None:
     """
-    Check ``_determine_api_scope()`` can correctly diagnose a trivial
+    Check ``_determine_thread_limit_scope()`` can correctly diagnose a trivial
     process-wide implementation.
     """
     api = FakeProcesswideAPI(default)
-    assert _determine_api_scope(api.get, api.set) == _APIScope.PROCESS
+    assert _determine_thread_limit_scope(api.get, api.set) == _ThreadLimitScope.PROCESS

--- a/tests/test_api_introspection.py
+++ b/tests/test_api_introspection.py
@@ -63,7 +63,7 @@ def test_determine_thread_limit_scope_processwide(default: int) -> None:
 
 
 @pytest.mark.skipif(
-    sys.platform != "linux", reason="We only hardcoded Linux-specific behavior"
+    sys.platform != "linux", reason="Non-Linux OpenMP might be different"
 )
 @pytest.mark.parametrize(
     ["select_filter", "expected_thread_limit_scope"],

--- a/tests/test_api_introspection.py
+++ b/tests/test_api_introspection.py
@@ -73,6 +73,12 @@ def test_determine_thread_limit_scope_processwide(default: int) -> None:
         (
             {"internal_api": "openblas"},
             _ThreadLimitScope.PROCESS,
+            # Different backends have different behavior; on Linux OpenMP is
+            # thread-local, for example, for libgomp/libomp at least. Since it
+            # depends on the specific OpenMP behavior, and since the goal here
+            # iin any case is to test _determine_thread_limit_scope()'s API
+            # specific ability to detect process-scoped APIs, we only check
+            # pthreads here.
             lambda lib: lib.threading_layer == "pthreads",
         ),
         ({"user_api": "openmp"}, _ThreadLimitScope.CURRENT_THREAD, lambda _lib: True),

--- a/tests/test_api_introspection.py
+++ b/tests/test_api_introspection.py
@@ -73,17 +73,15 @@ def test_determine_thread_limit_scope_processwide(default: int) -> None:
         (
             {"internal_api": "openblas"},
             _ThreadLimitScope.PROCESS,
-            lambda lib: lib.threading_layer == "pthreads"
+            lambda lib: lib.threading_layer == "pthreads",
         ),
-        (
-            {"user_api": "openmp"},
-            _ThreadLimitScope.CURRENT_THREAD,
-            lambda _lib: True
-        ),
+        ({"user_api": "openmp"}, _ThreadLimitScope.CURRENT_THREAD, lambda _lib: True),
     ],
 )
 def test_api_scope(
-        select_filter: dict[str, str], expected_thread_limit_scope: str, extra_check: Callable[[LibController], bool]
+    select_filter: dict[str, str],
+    expected_thread_limit_scope: str,
+    extra_check: Callable[[LibController], bool],
 ) -> None:
     """
     Check ``_determine_thread_limit_scope()`` against libraries with known

--- a/tests/test_api_introspection.py
+++ b/tests/test_api_introspection.py
@@ -9,7 +9,6 @@ from typing import Callable
 import pytest
 
 from threadpoolctl import (
-    _ThreadLimitScope,
     LibController,
     _determine_thread_limit_scope,
     ThreadpoolController,
@@ -48,10 +47,7 @@ def test_determine_thread_limit_scope_thread_local() -> None:
     thread-local implementation.
     """
     api = FakeThreadLocalAPI()
-    assert (
-        _determine_thread_limit_scope(api.get, api.set)
-        == _ThreadLimitScope.CURRENT_THREAD
-    )
+    assert _determine_thread_limit_scope(api.get, api.set) == "current_thread"
 
 
 @pytest.mark.parametrize("default", [1, 17])
@@ -61,7 +57,7 @@ def test_determine_thread_limit_scope_processwide(default: int) -> None:
     process-wide implementation.
     """
     api = FakeProcesswideAPI(default)
-    assert _determine_thread_limit_scope(api.get, api.set) == _ThreadLimitScope.PROCESS
+    assert _determine_thread_limit_scope(api.get, api.set) == "process"
 
 
 @pytest.mark.skipif(
@@ -72,7 +68,7 @@ def test_determine_thread_limit_scope_processwide(default: int) -> None:
     [
         (
             {"internal_api": "openblas"},
-            _ThreadLimitScope.PROCESS,
+            "process",
             # Different backends have different behavior; on Linux OpenMP is
             # thread-local, for example, for libgomp/libomp at least. Since it
             # depends on the specific OpenMP behavior, and since the goal here
@@ -81,7 +77,7 @@ def test_determine_thread_limit_scope_processwide(default: int) -> None:
             # pthreads here.
             lambda lib: lib.threading_layer == "pthreads",
         ),
-        ({"user_api": "openmp"}, _ThreadLimitScope.CURRENT_THREAD, lambda _lib: True),
+        ({"user_api": "openmp"}, "current_thread", lambda _lib: True),
     ],
 )
 def test_api_scope(

--- a/tests/test_api_introspection.py
+++ b/tests/test_api_introspection.py
@@ -4,11 +4,13 @@ Tests for get/set number of threads API introspection.
 
 import sys
 from threading import local as threadlocal
+from typing import Callable
 
 import pytest
 
 from threadpoolctl import (
     _ThreadLimitScope,
+    LibController,
     _determine_thread_limit_scope,
     ThreadpoolController,
 )
@@ -66,20 +68,22 @@ def test_determine_thread_limit_scope_processwide(default: int) -> None:
     sys.platform != "linux", reason="Non-Linux OpenMP might be different"
 )
 @pytest.mark.parametrize(
-    ["select_filter", "expected_thread_limit_scope"],
+    ["select_filter", "expected_thread_limit_scope", "extra_check"],
     [
         (
-            {"internal_api": "openblas", "threading_layer": "pthreads"},
+            {"internal_api": "openblas"},
             _ThreadLimitScope.PROCESS,
+            lambda lib: lib.threading_layer == "pthreads"
         ),
         (
             {"user_api": "openmp"},
             _ThreadLimitScope.CURRENT_THREAD,
+            lambda _lib: True
         ),
     ],
 )
 def test_api_scope(
-    select_filter: dict[str, str], expected_thread_limit_scope: str
+        select_filter: dict[str, str], expected_thread_limit_scope: str, extra_check: Callable[[LibController], bool]
 ) -> None:
     """
     Check ``_determine_thread_limit_scope()`` against libraries with known
@@ -91,6 +95,8 @@ def test_api_scope(
         pytest.skip(f"{select_filter} controller not found")
 
     for lib in controller.lib_controllers:
+        if not extra_check(lib):
+            pytest.skip("extra check returned false")
         assert (
             _determine_thread_limit_scope(lib.get_num_threads, lib.set_num_threads)
             == expected_thread_limit_scope

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -572,7 +572,7 @@ def test_command_line_command_flag():
     )
     cli_info = json.loads(output.decode("utf-8"))
 
-    this_process_info = threadpool_info()
+    this_process_info = threadpool_info(extra_info=True)
     for lib_info in cli_info:
         assert lib_info in this_process_info
 
@@ -598,7 +598,7 @@ def test_command_line_import_flag():
     )
     cli_info = json.loads(result.stdout)
 
-    this_process_info = threadpool_info()
+    this_process_info = threadpool_info(extra_info=True)
     for lib_info in cli_info:
         assert lib_info in this_process_info
 

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -813,7 +813,5 @@ def test_api_scope(select_filter: dict[str, str], expected_api_scope: str) -> No
     if not controller.lib_controllers:
         pytest.skip(f"{select_filter} controller not found")
 
-    # Filters should be limited to one result:
-    [lib] = controller.lib_controllers
-
-    assert lib.info()["api_scope"] == expected_api_scope
+    for lib in controller.lib_controllers:
+        assert lib.info()["api_scope"] == expected_api_scope

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import pytest
@@ -792,3 +794,26 @@ def test_custom_controller():
         assert mylib_controller.num_threads == 1
 
     assert ThreadpoolController().info() == original_info
+
+
+@pytest.mark.parametrize(
+    ["select_filter", "expected_api_scope"],
+    [
+        ({"internal_api": "openblas"}, "process"),
+        ({"internal_api": "mkl"}, "process"),
+        ({"internal_api": "blis"}, "process"),
+        ({"user_api": "openmp"}, "current_thread"),
+    ],
+)
+def test_api_scope(select_filter: dict[str, str], expected_api_scope: str) -> None:
+    """
+    For the given controller, expect the given API scope.
+    """
+    controller = ThreadpoolController().select(**select_filter)
+    if not controller.lib_controllers:
+        pytest.skip(f"{select_filter} controller not found")
+
+    # Filters should be limited to one result:
+    [lib] = controller.lib_controllers
+
+    assert lib.info()["api_scope"] == expected_api_scope

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -794,24 +794,3 @@ def test_custom_controller():
         assert mylib_controller.num_threads == 1
 
     assert ThreadpoolController().info() == original_info
-
-
-@pytest.mark.parametrize(
-    ["select_filter", "expected_api_scope"],
-    [
-        ({"internal_api": "openblas"}, "process"),
-        ({"internal_api": "mkl"}, "process"),
-        ({"internal_api": "blis"}, "process"),
-        ({"user_api": "openmp"}, "current_thread"),
-    ],
-)
-def test_api_scope(select_filter: dict[str, str], expected_api_scope: str) -> None:
-    """
-    For the given controller, expect the given API scope.
-    """
-    controller = ThreadpoolController().select(**select_filter)
-    if not controller.lib_controllers:
-        pytest.skip(f"{select_filter} controller not found")
-
-    for lib in controller.lib_controllers:
-        assert lib.info()["api_scope"] == expected_api_scope

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -615,6 +615,7 @@ def test_architecture():
     expected_openblas_architectures = (
         # XXX: add more as needed by CI or developer laptops
         "armv8",
+        "cooperlake",
         "haswell",
         "neoversen1",
         "prescott",  # see: https://github.com/xianyi/OpenBLAS/pull/3485

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -572,7 +572,7 @@ def test_command_line_command_flag():
     )
     cli_info = json.loads(output.decode("utf-8"))
 
-    this_process_info = threadpool_info(extra_info=True)
+    this_process_info = threadpool_info(debugging_info=True)
     for lib_info in cli_info:
         assert lib_info in this_process_info
 
@@ -598,7 +598,7 @@ def test_command_line_import_flag():
     )
     cli_info = json.loads(result.stdout)
 
-    this_process_info = threadpool_info(extra_info=True)
+    this_process_info = threadpool_info(debugging_info=True)
     for lib_info in cli_info:
         assert lib_info in this_process_info
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -208,9 +208,11 @@ class LibController(ABC):
             "user_api": self.user_api,
             "internal_api": self.internal_api,
             "num_threads": self.num_threads,
-            "api_scope": _determine_api_scope(
-                self.get_num_threads, self.set_num_threads
-            ).value.lower(),
+            "api_scope": (
+                _determine_api_scope(
+                    self.get_num_threads, self.set_num_threads
+                ).value.lower()
+            ),
             **{k: v for k, v in vars(self).items() if k not in hidden_attrs},
         }
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -201,20 +201,28 @@ class LibController(ABC):
         self.version = self.get_version()
         self.set_additional_attributes()
 
-    def info(self):
-        """Return relevant info wrapped in a dict"""
+    def info(self, extra_info: bool = False):
+        """Return relevant info wrapped in a dict.
+
+        Parameters
+        ----------
+        extra_info : bool
+
+            Include extra fields which requires more intrusive actions to
+            obtain.
+        """
         hidden_attrs = ("dynlib", "parent", "_symbol_prefix", "_symbol_suffix")
-        return {
+        result = {
             "user_api": self.user_api,
             "internal_api": self.internal_api,
             "num_threads": self.num_threads,
-            "api_scope": (
-                _determine_api_scope(
-                    self.get_num_threads, self.set_num_threads
-                ).name.lower()
-            ),
             **{k: v for k, v in vars(self).items() if k not in hidden_attrs},
         }
+        if extra_info:
+            result["api_scope"] = _determine_api_scope(
+                self.get_num_threads, self.set_num_threads
+            ).name.lower()
+        return result
 
     def set_additional_attributes(self):
         """Set additional attributes meant to be exposed in the info dict"""
@@ -639,7 +647,7 @@ def _realpath(filepath):
 
 
 @_format_docstring(USER_APIS=list(_ALL_USER_APIS), INTERNAL_APIS=_ALL_INTERNAL_APIS)
-def threadpool_info():
+def threadpool_info(extra_info: bool = False):
     """Return the maximal number of threads for each detected library.
 
     Return a list with all the supported libraries that have been found. Each
@@ -653,8 +661,18 @@ def threadpool_info():
       - "num_threads": the current thread limit.
 
     In addition, each library may contain internal_api specific entries.
+
+    Parameters
+        ----------
+        extra_info : bool
+
+            Include extra fields which requires more intrusive actions to
+            obtain.
+
+            - "api_scope": When setting the number of threads, what is affected.
+                           Possible values are "process", "current_thread".
     """
-    return ThreadpoolController().info()
+    return ThreadpoolController().info(extra_info)
 
 
 class _ThreadpoolLimiter:
@@ -914,9 +932,20 @@ class ThreadpoolController:
         new_controller.lib_controllers = lib_controllers
         return new_controller
 
-    def info(self):
-        """Return lib_controllers info as a list of dicts"""
-        return [lib_controller.info() for lib_controller in self.lib_controllers]
+    def info(self, extra_info: bool = False):
+        """Return lib_controllers info as a list of dicts.
+
+        Parameters
+        ----------
+        extra_info : bool
+
+            Include extra fields which requires more intrusive actions to
+            obtain.
+        """
+        return [
+            lib_controller.info(extra_info=extra_info)
+            for lib_controller in self.lib_controllers
+        ]
 
     def select(self, **kwargs):
         """Return a ThreadpoolController containing a subset of its current
@@ -1380,7 +1409,7 @@ def _main():
     if options.command:
         exec(options.command)
 
-    print(json.dumps(threadpool_info(), indent=2))
+    print(json.dumps(threadpool_info(extra_info=True), indent=2))
 
 
 if __name__ == "__main__":

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -670,14 +670,12 @@ def threadpool_info(extra_info: bool = False):
     In addition, each library may contain internal_api specific entries.
 
     Parameters
-        ----------
-        extra_info : bool
-
-            Include extra fields which requires more intrusive actions to
-            obtain.
-
-            - "api_scope": When setting the number of threads, what is affected.
-                           Possible values are "process", "current_thread".
+    ----------
+    extra_info : bool
+        Include extra fields which requires more intrusive actions to obtain.
+ 
+        - "api_scope": When setting the number of threads, what is affected.
+          Possible values are "process", "current_thread".
     """
     return ThreadpoolController().info(extra_info)
 
@@ -945,7 +943,6 @@ class ThreadpoolController:
         Parameters
         ----------
         extra_info : bool
-
             Include extra fields which requires more intrusive actions to
             obtain.
         """

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -93,9 +93,16 @@ def _determine_api_scope(
     """
     Run some experiments to determine the scope of the given get/set API.
 
-    An attempt will be made to restore all settings to their previous state.
+    This function might not work if you only have one core available.
 
-    This won't work if you only have one core available.
+    This function might not work if you set a limit on a library with an
+    environment variable.
+
+    The function works by changing the number of threads in loaded controllers,
+    which can be a process-wide change. As such, it is not always thread-safe.
+    An attempt will be made to restore all settings to their previous state,
+    but the result may be subtly different, e.g. if "unset" has different
+    semantics than "set to the default returned value".
     """
     if os.cpu_count() == 1 or (
         hasattr(os, "process_cpu_count") and os.process_cpu_count() == 1
@@ -108,7 +115,7 @@ def _determine_api_scope(
     #
     # 1. The API might not allow setting more than the number of (available, or
     #    physical) cores.
-    # 2. ...
+    # 2. Some hard limit on number of threads.
     try:
         # Choose a desired number of threads that is different than the current
         # number, and hopefully achievable under the current configuration:
@@ -130,13 +137,13 @@ def _determine_api_scope(
 
         # First, getting in the same thread as a set should always give same
         # number, if it's a number in a reasonable range. A possible exception
-        # is if the number of thread is limited by available CPU, and only one
-        # CPU is available. In that case we can't empirically determine how the
-        # API works. We try to not reach that point here, but you can imagine a
-        # thread pool implementation that is aware of cgroups, in which case a
-        # Docker container limited to one core will pass the safety check at
-        # the start of the function. Perhaps cpu_count() from loky should be
-        # moved into this package...
+        # fo failing this is if the number of thread is limited by available
+        # CPU, and only one CPU is available. In that case we can't empirically
+        # determine how the API works. We try to not reach that point here, but
+        # you can imagine a thread pool implementation that is aware of
+        # cgroups, in which case a Docker container limited to one core will
+        # pass the safety check at the start of the function. Perhaps
+        # cpu_count() from loky should be moved into this package...
         if thread_result != [expected]:
             return _APIScope.UNKNOWN
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -24,7 +24,7 @@ from ctypes.util import find_library
 from abc import ABC, abstractmethod
 from functools import lru_cache
 from contextlib import ContextDecorator
-from enum import StrEnum, auto
+from enum import Enum, auto
 
 __version__ = "3.7.0.dev0"
 __all__ = [
@@ -71,7 +71,7 @@ except AttributeError:
     _RTLD_NOLOAD = ctypes.DEFAULT_MODE
 
 
-class _APIScope(StrEnum):
+class _APIScope(Enum):
     """
     What scope does the API affect.
     """
@@ -211,7 +211,7 @@ class LibController(ABC):
             "api_scope": (
                 _determine_api_scope(
                     self.get_num_threads, self.set_num_threads
-                ).value.lower()
+                ).name.lower()
             ),
             **{k: v for k, v in vars(self).items() if k not in hidden_attrs},
         }

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -76,14 +76,14 @@ class _APIScope(Enum):
     What scope does the API affect.
     """
 
-    # Using the API sets a limit only on the current thread:
-    THREAD_LOCAL = auto()
+    # Using the API sets a limit only on the current thread.
+    CURRENT_THREAD = auto()
     # Using the API sets a limit for every thread in the process; whether or
     # not it's a shared process-wide pool or per-thread limit needs to be
     # determined some other way.
-    PROCESSWIDE = auto()
-    # Something else, unexpected; perhaps an unknown API, perhaps information
-    # can't be determined under current configuration:
+    PROCESS = auto()
+    # Something else, unexpected; perhaps another variant, perhaps information
+    # can't be determined under the current configuration.
     UNKNOWN = auto()
 
 
@@ -95,7 +95,7 @@ def _determine_api_scope(
 
     An attempt will be made to restore all settings to their previous state.
 
-    This won't work reliably if you only have one core available.
+    This won't work if you only have one core available.
     """
     if os.cpu_count() == 1 or (
         hasattr(os, "process_cpu_count") and os.process_cpu_count() == 1
@@ -142,11 +142,11 @@ def _determine_api_scope(
 
         # Now, check this thread:
         if get_n_threads() == expected:
-            # Setting is process-wide.
-            return _APIScope.PROCESSWIDE
+            # Setting modified this thread's results too:
+            return _APIScope.PROCESS
         elif get_n_threads() == previous:
-            # Setting modified the other thread, but not this one.
-            return _APIScope.THREAD_LOCAL
+            # Setting modified the other thread, but not this one:
+            return _APIScope.CURRENT_THREAD
         else:
             # No idea what's going on:
             return _APIScope.UNKNOWN

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -71,7 +71,7 @@ except AttributeError:
     _RTLD_NOLOAD = ctypes.DEFAULT_MODE
 
 
-class _APIScope(Enum):
+class _ThreadLimitScope(Enum):
     """
     What scope does the API affect.
     """
@@ -87,9 +87,9 @@ class _APIScope(Enum):
     UNKNOWN = auto()
 
 
-def _determine_api_scope(
+def _determine_thread_limit_scope(
     get_n_threads: Callable[[], int], set_n_threads: Callable[[int], None]
-) -> _APIScope:
+) -> _ThreadLimitScope:
     """
     Run some experiments to determine the scope of the given get/set API.
 
@@ -104,11 +104,6 @@ def _determine_api_scope(
     but the result may be subtly different, e.g. if "unset" has different
     semantics than "set to the default returned value".
     """
-    if os.cpu_count() == 1 or (
-        hasattr(os, "process_cpu_count") and os.process_cpu_count() == 1
-    ):
-        raise RuntimeError("Cannot determine API meaning if only one core is available")
-
     previous = get_n_threads()
 
     # Some plausible constraints we need to keep in mind:
@@ -145,18 +140,18 @@ def _determine_api_scope(
         # pass the safety check at the start of the function. Perhaps
         # cpu_count() from loky should be moved into this package...
         if thread_result != [expected]:
-            return _APIScope.UNKNOWN
+            return _ThreadLimitScope.UNKNOWN
 
         # Now, check this thread:
         if get_n_threads() == expected:
             # Setting modified this thread's results too:
-            return _APIScope.PROCESS
+            return _ThreadLimitScope.PROCESS
         elif get_n_threads() == previous:
             # Setting modified the other thread, but not this one:
-            return _APIScope.CURRENT_THREAD
+            return _ThreadLimitScope.CURRENT_THREAD
         else:
             # No idea what's going on:
-            return _APIScope.UNKNOWN
+            return _ThreadLimitScope.UNKNOWN
     finally:
         set_n_threads(previous)
 
@@ -226,7 +221,7 @@ class LibController(ABC):
             **{k: v for k, v in vars(self).items() if k not in hidden_attrs},
         }
         if extra_info:
-            result["api_scope"] = _determine_api_scope(
+            result["thread_limit_scope"] = _determine_thread_limit_scope(
                 self.get_num_threads, self.set_num_threads
             ).name.lower()
         return result
@@ -673,9 +668,9 @@ def threadpool_info(extra_info: bool = False):
     ----------
     extra_info : bool
         Include extra fields which requires more intrusive actions to obtain.
- 
-        - "api_scope": When setting the number of threads, what is affected.
-          Possible values are "process", "current_thread".
+
+        - "thread_limit_scope": When setting the number of threads, what is
+          affected. Possible values are "process", "current_thread".
     """
     return ThreadpoolController().info(extra_info)
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -17,15 +17,19 @@ import sys
 import ctypes
 import itertools
 import textwrap
-from typing import final
+from threading import Thread
+from typing import Callable, final
 import warnings
 from ctypes.util import find_library
 from abc import ABC, abstractmethod
 from functools import lru_cache
 from contextlib import ContextDecorator
+from enum import Enum, auto
 
 __version__ = "3.7.0.dev0"
 __all__ = [
+    "APIScope",
+    "determine_api_scope",
     "threadpool_limits",
     "threadpool_info",
     "ThreadpoolController",
@@ -67,6 +71,89 @@ try:
     _RTLD_NOLOAD = os.RTLD_NOLOAD
 except AttributeError:
     _RTLD_NOLOAD = ctypes.DEFAULT_MODE
+
+
+class APIScope(Enum):
+    """
+    What scope does the API affect.
+    """
+
+    # Using the API sets a limit only on the current thread:
+    THREAD_LOCAL = auto()
+    # Using the API sets a limit for every thread in the process; whether or
+    # not it's a shared process-wide pool or per-thread limit needs to be
+    # determined some other way.
+    PROCESSWIDE = auto()
+    # Something else, unexpected; perhaps an unknown API, perhaps information
+    # can't be determined under current configuration:
+    UNKNOWN = auto()
+
+
+def determine_api_scope(
+    get_n_threads: Callable[[], int], set_n_threads: Callable[[int], None]
+) -> APIScope:
+    """
+    Run some experiments to determine the scope of the given get/set API.
+
+    An attempt will be made to restore all settings to their previous state.
+
+    This won't work reliably if you only have one core available.
+    """
+    if os.cpu_count() == 1 or (
+        hasattr(os, "process_cpu_count") and os.process_cpu_count() == 1
+    ):
+        raise RuntimeError("Cannot determine API meaning if only one core is available")
+
+    previous = get_n_threads()
+
+    # Some plausible constraints we need to keep in mind:
+    #
+    # 1. The API might not allow setting more than the number of (available, or
+    #    physical) cores.
+    # 2. ...
+    try:
+        # Choose a desired number of threads that is different than the current
+        # number, and hopefully achievable under the current configuration:
+        if previous < 2:
+            expected = 2
+        else:
+            # It's 2 or more, so shrink it slightly:
+            expected = previous - 1
+
+        thread_result = []
+
+        def get_and_set() -> None:
+            set_n_threads(expected)
+            thread_result.append(get_n_threads())
+
+        thread = Thread(target=get_and_set)
+        thread.start()
+        thread.join()
+
+        # First, getting in the same thread as a set should always give same
+        # number, if it's a number in a reasonable range. A possible exception
+        # is if the number of thread is limited by available CPU, and only one
+        # CPU is available. In that case we can't empirically determine how the
+        # API works. We try to not reach that point here, but you can imagine a
+        # thread pool implementation that is aware of cgroups, in which case a
+        # Docker container limited to one core will pass the safety check at
+        # the start of the function. Perhaps cpu_count() from loky should be
+        # moved into this package...
+        if thread_result != [expected]:
+            return APIScope.UNKNOWN
+
+        # Now, check this thread:
+        if get_n_threads() == expected:
+            # Setting is process-wide.
+            return APIScope.PROCESSWIDE
+        elif get_n_threads() == previous:
+            # Setting modified the other thread, but not this one.
+            return APIScope.THREAD_LOCAL
+        else:
+            # No idea what's going on:
+            return APIScope.UNKNOWN
+    finally:
+        set_n_threads(previous)
 
 
 class LibController(ABC):

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -24,12 +24,10 @@ from ctypes.util import find_library
 from abc import ABC, abstractmethod
 from functools import lru_cache
 from contextlib import ContextDecorator
-from enum import Enum, auto
+from enum import StrEnum, auto
 
 __version__ = "3.7.0.dev0"
 __all__ = [
-    "APIScope",
-    "determine_api_scope",
     "threadpool_limits",
     "threadpool_info",
     "ThreadpoolController",
@@ -73,7 +71,7 @@ except AttributeError:
     _RTLD_NOLOAD = ctypes.DEFAULT_MODE
 
 
-class APIScope(Enum):
+class _APIScope(StrEnum):
     """
     What scope does the API affect.
     """
@@ -89,9 +87,9 @@ class APIScope(Enum):
     UNKNOWN = auto()
 
 
-def determine_api_scope(
+def _determine_api_scope(
     get_n_threads: Callable[[], int], set_n_threads: Callable[[int], None]
-) -> APIScope:
+) -> _APIScope:
     """
     Run some experiments to determine the scope of the given get/set API.
 
@@ -140,18 +138,18 @@ def determine_api_scope(
         # the start of the function. Perhaps cpu_count() from loky should be
         # moved into this package...
         if thread_result != [expected]:
-            return APIScope.UNKNOWN
+            return _APIScope.UNKNOWN
 
         # Now, check this thread:
         if get_n_threads() == expected:
             # Setting is process-wide.
-            return APIScope.PROCESSWIDE
+            return _APIScope.PROCESSWIDE
         elif get_n_threads() == previous:
             # Setting modified the other thread, but not this one.
-            return APIScope.THREAD_LOCAL
+            return _APIScope.THREAD_LOCAL
         else:
             # No idea what's going on:
-            return APIScope.UNKNOWN
+            return _APIScope.UNKNOWN
     finally:
         set_n_threads(previous)
 
@@ -210,6 +208,9 @@ class LibController(ABC):
             "user_api": self.user_api,
             "internal_api": self.internal_api,
             "num_threads": self.num_threads,
+            "api_scope": _determine_api_scope(
+                self.get_num_threads, self.set_num_threads
+            ).value.lower(),
             **{k: v for k, v in vars(self).items() if k not in hidden_attrs},
         }
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -670,7 +670,7 @@ def threadpool_info(extra_info: bool = False):
         Include extra fields which requires more intrusive actions to obtain.
 
         - "thread_limit_scope": When setting the number of threads, what is
-          affected. Possible values are "process", "current_thread".
+          affected. Possible values are "process", "current_thread", "unknown".
     """
     return ThreadpoolController().info(extra_info)
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -418,11 +418,11 @@ class FlexiBLASController(LibController):
     def current_backend(self):
         return self._get_current_backend()
 
-    def info(self):
+    def info(self, debugging_info=True):
         """Return relevant info wrapped in a dict"""
         # We override the info method because the loaded and current backends
         # are dynamic properties
-        exposed_attrs = super().info()
+        exposed_attrs = super().info(debugging_info=debugging_info)
         exposed_attrs["loaded_backends"] = self.loaded_backends
         exposed_attrs["current_backend"] = self.current_backend
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -203,15 +203,15 @@ class LibController(ABC):
         self.version = self.get_version()
         self.set_additional_attributes()
 
-    def info(self, extra_info: bool = False):
+    def info(self, debugging_info: bool = False):
         """Return relevant info wrapped in a dict.
 
         Parameters
         ----------
-        extra_info : bool
+        debugging_info : bool
 
-            Include extra fields which requires more intrusive actions to
-            obtain.
+            Include extra fields which require more intrusive actions to
+            obtain, and which can't always reliably be determined.
         """
         hidden_attrs = ("dynlib", "parent", "_symbol_prefix", "_symbol_suffix")
         result = {
@@ -220,7 +220,7 @@ class LibController(ABC):
             "num_threads": self.num_threads,
             **{k: v for k, v in vars(self).items() if k not in hidden_attrs},
         }
-        if extra_info:
+        if debugging_info:
             result["thread_limit_scope"] = _determine_thread_limit_scope(
                 self.get_num_threads, self.set_num_threads
             ).name.lower()
@@ -649,7 +649,7 @@ def _realpath(filepath):
 
 
 @_format_docstring(USER_APIS=list(_ALL_USER_APIS), INTERNAL_APIS=_ALL_INTERNAL_APIS)
-def threadpool_info(extra_info: bool = False):
+def threadpool_info(debugging_info: bool = False):
     """Return the maximal number of threads for each detected library.
 
     Return a list with all the supported libraries that have been found. Each
@@ -666,13 +666,14 @@ def threadpool_info(extra_info: bool = False):
 
     Parameters
     ----------
-    extra_info : bool
-        Include extra fields which requires more intrusive actions to obtain.
+    debugging_info : bool
+        Include extra fields which require more intrusive actions to obtain,
+        and which can't always reliably be determined.
 
         - "thread_limit_scope": When setting the number of threads, what is
           affected. Possible values are "process", "current_thread", "unknown".
     """
-    return ThreadpoolController().info(extra_info)
+    return ThreadpoolController().info(debugging_info)
 
 
 class _ThreadpoolLimiter:
@@ -932,17 +933,17 @@ class ThreadpoolController:
         new_controller.lib_controllers = lib_controllers
         return new_controller
 
-    def info(self, extra_info: bool = False):
+    def info(self, debugging_info: bool = False):
         """Return lib_controllers info as a list of dicts.
 
         Parameters
         ----------
-        extra_info : bool
-            Include extra fields which requires more intrusive actions to
-            obtain.
+        debugging_info : bool
+            Include extra fields which require more intrusive actions to
+            obtain, and which can't always reliably be determined.
         """
         return [
-            lib_controller.info(extra_info=extra_info)
+            lib_controller.info(debugging_info=debugging_info)
             for lib_controller in self.lib_controllers
         ]
 
@@ -1408,7 +1409,7 @@ def _main():
     if options.command:
         exec(options.command)
 
-    print(json.dumps(threadpool_info(extra_info=True), indent=2))
+    print(json.dumps(threadpool_info(debugging_info=True), indent=2))
 
 
 if __name__ == "__main__":

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -418,7 +418,7 @@ class FlexiBLASController(LibController):
     def current_backend(self):
         return self._get_current_backend()
 
-    def info(self, debugging_info=True):
+    def info(self, debugging_info: bool = False):
         """Return relevant info wrapped in a dict"""
         # We override the info method because the loaded and current backends
         # are dynamic properties

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -18,13 +18,12 @@ import ctypes
 import itertools
 import textwrap
 from threading import Thread
-from typing import Callable, final
+from typing import Callable, Literal, final
 import warnings
 from ctypes.util import find_library
 from abc import ABC, abstractmethod
 from functools import lru_cache
 from contextlib import ContextDecorator
-from enum import Enum, auto
 
 __version__ = "3.7.0.dev0"
 __all__ = [
@@ -71,20 +70,18 @@ except AttributeError:
     _RTLD_NOLOAD = ctypes.DEFAULT_MODE
 
 
-class _ThreadLimitScope(Enum):
-    """
-    What scope does the API affect.
-    """
-
+# What scope does the API affect?
+_ThreadLimitScope = Literal[
     # Using the API sets a limit only on the current thread.
-    CURRENT_THREAD = auto()
+    "current_thread",
     # Using the API sets a limit for every thread in the process; whether or
     # not it's a shared process-wide pool or per-thread limit needs to be
     # determined some other way.
-    PROCESS = auto()
+    "process",
     # Something else, unexpected; perhaps another variant, perhaps information
     # can't be determined under the current configuration.
-    UNKNOWN = auto()
+    "unknown",
+]
 
 
 def _determine_thread_limit_scope(
@@ -140,18 +137,18 @@ def _determine_thread_limit_scope(
         # pass the safety check at the start of the function. Perhaps
         # cpu_count() from loky should be moved into this package...
         if thread_result != [expected]:
-            return _ThreadLimitScope.UNKNOWN
+            return "unknown"
 
         # Now, check this thread:
         if get_n_threads() == expected:
             # Setting modified this thread's results too:
-            return _ThreadLimitScope.PROCESS
+            return "process"
         elif get_n_threads() == previous:
             # Setting modified the other thread, but not this one:
-            return _ThreadLimitScope.CURRENT_THREAD
+            return "current_thread"
         else:
             # No idea what's going on:
-            return _ThreadLimitScope.UNKNOWN
+            return "unknown"
     finally:
         set_n_threads(previous)
 
@@ -223,7 +220,7 @@ class LibController(ABC):
         if debugging_info:
             result["thread_limit_scope"] = _determine_thread_limit_scope(
                 self.get_num_threads, self.set_num_threads
-            ).name.lower()
+            )
         return result
 
     def set_additional_attributes(self):


### PR DESCRIPTION
Fixes #211.

Add info to determine the scope of the thread-limit-setting API (thread local, process-wide, unknown). Introspecting the semantics of the thread pool are going to be a separate PR, assuming that can be done reasonably.