### PR TITLE
FIX intermittent Windows module enumeration failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,22 +51,26 @@ jobs:
             PYTHON_VERSION: "*"
             PACKAGER: "conda-forge"
             BLAS: "mkl"
+            INSTALL_OPENCV: "true"
           # Windows env with numpy, scipy, OpenBLAS installed through conda-forge
           - name: py311_conda_forge_openblas
             os: windows-latest
             PYTHON_VERSION: "3.11"
             PACKAGER: "conda-forge"
             BLAS: "openblas"
+            INSTALL_OPENCV: "true"
           # Windows env with numpy, scipy installed through conda
           - name: py310_conda
             os: windows-latest
             PYTHON_VERSION: "3.10"
             PACKAGER: "conda"
+            INSTALL_OPENCV: "true"
           # Windows env with numpy, scipy installed through pip
           - name: py39_pip
             os: windows-latest
             PYTHON_VERSION: "3.9"
             PACKAGER: "pip"
+            INSTALL_OPENCV: "true"
 
           # MacOS env with OpenMP installed through homebrew
           - name: py39_conda_homebrew_libomp
@@ -157,6 +161,7 @@ jobs:
             PYTHON_VERSION: "*"
             BLAS: "openblas"
             OPENBLAS_THREADING_LAYER: "openmp"
+            INSTALL_OPENCV: "true"
             CC_OUTER_LOOP: "gcc"
             CC_INNER_LOOP: "gcc"
           # Linux environment with no numpy and heterogeneous OpenMP runtimes.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,9 @@
 
 - Fixed an intermittent `OSError` on Windows when DLLs are loaded or unloaded
   concurrently during library discovery (for example when importing conda-forge
-  OpenCV). Windows module enumeration now uses a snapshot-first approach with
-  graceful per-module fallbacks.
+  OpenCV). On Python 3.14+, discovery uses `ctypes.util.dllist` when available
+  and falls back to a Toolhelp snapshot if that raises. Older Pythons use the
+  snapshot enumerator, with graceful per-module fallbacks.
   https://github.com/joblib/threadpoolctl/pull/219
 
 - Added the ability to check whether a limiting API affects just the current

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+3.7.0 (TBD)
+===========
+
+- Fixed an intermittent `OSError` on Windows when DLLs are loaded or unloaded
+  concurrently during library discovery (for example when importing conda-forge
+  OpenCV). Windows module enumeration now uses a snapshot-first approach with
+  graceful per-module fallbacks.
+  https://github.com/joblib/threadpoolctl/issues/217
+
+- Added Windows integration tests for library paths longer than `MAX_PATH`.
+  https://github.com/joblib/threadpoolctl/pull/189
+
 3.6.0 (2025-03-13)
 ==================
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,9 +7,6 @@
   graceful per-module fallbacks.
   https://github.com/joblib/threadpoolctl/issues/217
 
-- Added Windows integration tests for library paths longer than `MAX_PATH`.
-  https://github.com/joblib/threadpoolctl/pull/189
-
 3.6.0 (2025-03-13)
 ==================
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,9 @@
 
 - Fixed an intermittent `OSError` on Windows when DLLs are loaded or unloaded
   concurrently during library discovery (for example when importing conda-forge
-  OpenCV). On Python 3.14+, discovery uses `ctypes.util.dllist` when available
-  and falls back to a Toolhelp snapshot if that raises. Older Pythons use the
-  snapshot enumerator, with graceful per-module fallbacks.
+  OpenCV). On Python 3.14+, discovery uses `ctypes.util.dllist` when available.
+  Older Pythons use a Toolhelp snapshot enumerator, with graceful per-module
+  fallbacks.
   https://github.com/joblib/threadpoolctl/pull/219
 
 - Added the ability to check whether a limiting API affects just the current

--- a/continuous_integration/check_no_test_skipped.py
+++ b/continuous_integration/check_no_test_skipped.py
@@ -36,7 +36,12 @@ print("\n------------------------------------------------------------------\n")
 # List of tests that we don't want to fail the CI if they are skipped in
 # every job. This is useful for tests that depend on specific versions of
 # numpy or scipy and we don't want to pin old versions of these libraries.
-SAFE_SKIPPED_TESTS = ["test_multiple_shipped_openblas"]
+SAFE_SKIPPED_TESTS = [
+    "test_multiple_shipped_openblas",
+    # Requires Windows with shipped OpenBLAS (e.g. py311_conda_forge_openblas).
+    "test_windows_library_path_longer_than_max_path",
+    "test_windows_library_path_exceeds_internal_limit",
+]
 
 fail = False
 for test, skipped in always_skipped.items():

--- a/continuous_integration/check_no_test_skipped.py
+++ b/continuous_integration/check_no_test_skipped.py
@@ -36,12 +36,7 @@ print("\n------------------------------------------------------------------\n")
 # List of tests that we don't want to fail the CI if they are skipped in
 # every job. This is useful for tests that depend on specific versions of
 # numpy or scipy and we don't want to pin old versions of these libraries.
-SAFE_SKIPPED_TESTS = [
-    "test_multiple_shipped_openblas",
-    # Requires Windows with shipped OpenBLAS (e.g. py311_conda_forge_openblas).
-    "test_windows_library_path_longer_than_max_path",
-    "test_windows_library_path_exceeds_internal_limit",
-]
+SAFE_SKIPPED_TESTS = ["test_multiple_shipped_openblas"]
 
 fail = False
 for test, skipped in always_skipped.items():

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -66,12 +66,18 @@ if [[ "$PACKAGER" == "conda" ]]; then
             TO_INSTALL="$TO_INSTALL blas=*=$BLAS"
         fi
     fi
+    if [[ "$INSTALL_OPENCV" == "true" ]]; then
+        TO_INSTALL="$TO_INSTALL opencv"
+    fi
 	make_conda "defaults" "$TO_INSTALL"
 
 elif [[ "$PACKAGER" == "conda-forge" ]]; then
     TO_INSTALL="numpy scipy blas=*=$BLAS"
     if [[ "$BLAS" == "openblas" && "$OPENBLAS_THREADING_LAYER" == "openmp" ]]; then
         TO_INSTALL="$TO_INSTALL libopenblas=*=*openmp*"
+    fi
+    if [[ "$INSTALL_OPENCV" == "true" ]]; then
+        TO_INSTALL="$TO_INSTALL opencv"
     fi
     make_conda "conda-forge" "$TO_INSTALL"
 
@@ -81,6 +87,9 @@ elif [[ "$PACKAGER" == "pip" ]]; then
     make_conda "conda-forge" ""
     if [[ "$NO_NUMPY" != "true" ]]; then
         pip install numpy scipy
+    fi
+    if [[ "$INSTALL_OPENCV" == "true" ]]; then
+        pip install opencv-python
     fi
 
 elif [[ "$PACKAGER" == "pip-dev" ]]; then

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -835,7 +835,12 @@ def test_windows_library_path_longer_than_max_path(tmp_path):
         tmp_path, "libopenblas_long_path_test.dll", min_length=261
     )
     extended_path = os.path.abspath(str(long_path))
+    # Win32 APIs reject paths longer than MAX_PATH unless they use the
+    # extended-length prefix ``\\?\``. Skip rewriting if abspath already
+    # returned that form.
     if not extended_path.startswith("\\\\?\\"):
+        # UNC paths (``\\server\share\...``) need ``\\?\UNC\server\share\...``
+        # rather than ``\\?\\server\...``.
         if extended_path.startswith("\\\\"):
             extended_path = "\\\\?\\UNC\\" + extended_path[2:]
         else:
@@ -844,6 +849,9 @@ def test_windows_library_path_longer_than_max_path(tmp_path):
     ctypes.CDLL(extended_path)
 
     expected_path = os.path.abspath(str(long_path))
+    # Compare using the canonical path without the ``\\?\`` prefix.
+    # ``\\?\C:\...`` becomes ``C:\...``; ``\\?\UNC\server\share`` becomes
+    # ``\\server\share``.
     if expected_path.startswith("\\\\?\\"):
         expected_path = expected_path[4:]
         if expected_path.startswith("UNC\\"):
@@ -856,6 +864,8 @@ def test_windows_library_path_longer_than_max_path(tmp_path):
     normalized_filepaths = []
     for info in long_path_entries:
         filepath = info["filepath"]
+        # Same prefix stripping as expected_path so discovery results match
+        # regardless of whether GetModuleFileNameExW kept ``\\?\``.
         if filepath.startswith("\\\\?\\"):
             filepath = filepath[4:]
             if filepath.startswith("UNC\\"):

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -7,7 +7,7 @@ import sys
 
 import threadpoolctl
 from threadpoolctl import threadpool_limits, threadpool_info
-from threadpoolctl import ThreadpoolController, _realpath
+from threadpoolctl import ThreadpoolController
 from threadpoolctl import _ALL_PREFIXES, _ALL_USER_APIS
 
 from .utils import cython_extensions_compiled
@@ -15,7 +15,10 @@ from .utils import check_nested_prange_blas
 from .utils import libopenblas_paths
 from .utils import copy_and_load_dll
 from .utils import get_openblas_dll_path
+from .utils import LONG_PATH_OPENBLAS_DLL
 from .utils import make_long_windows_path
+from .utils import normalize_windows_path
+from .utils import TRUNCATED_PATH_OPENBLAS_DLL
 from .utils import scipy
 from .utils import threadpool_info_from_subprocess
 from .utils import select
@@ -820,17 +823,17 @@ def test_windows_library_path_longer_than_max_path(tmp_path):
     if src_dll is None:
         pytest.skip("Requires OpenBLAS on Windows")
 
-    dll_name = os.path.basename(src_dll)
-    long_path = make_long_windows_path(tmp_path, dll_name, min_length=261)
+    long_path = make_long_windows_path(tmp_path, LONG_PATH_OPENBLAS_DLL, min_length=261)
     copy_and_load_dll(src_dll, long_path)
 
-    expected_path = _realpath(str(long_path))
+    expected_path = normalize_windows_path(long_path)
     openblas_info = ThreadpoolController().select(internal_api="openblas").info()
 
     long_path_entries = [info for info in openblas_info if len(info["filepath"]) > 260]
     assert len(long_path_entries) >= 1
     assert any(
-        _realpath(info["filepath"]) == expected_path for info in long_path_entries
+        normalize_windows_path(info["filepath"]) == expected_path
+        for info in long_path_entries
     )
 
 
@@ -847,13 +850,18 @@ def test_windows_library_path_exceeds_internal_limit(tmp_path, monkeypatch):
 
     monkeypatch.setattr(threadpoolctl, "_WINDOWS_MAX_LIBRARY_PATH_LENGTH", 300)
 
-    dll_name = "libopenblas_path_too_long.dll"
-    long_path = make_long_windows_path(tmp_path, dll_name, min_length=301)
+    long_path = make_long_windows_path(
+        tmp_path, TRUNCATED_PATH_OPENBLAS_DLL, min_length=400
+    )
     copy_and_load_dll(src_dll, long_path)
 
-    expected_path = _realpath(str(long_path))
+    expected_path = normalize_windows_path(long_path)
     with pytest.warns(RuntimeWarning, match="path too long"):
         info = ThreadpoolController().info()
 
-    filepaths = {_realpath(entry["filepath"]) for entry in info if "filepath" in entry}
+    filepaths = {
+        normalize_windows_path(entry["filepath"])
+        for entry in info
+        if "filepath" in entry
+    }
     assert expected_path not in filepaths

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -15,6 +15,7 @@ from threadpoolctl import _ALL_PREFIXES, _ALL_USER_APIS
 from .utils import cython_extensions_compiled
 from .utils import check_nested_prange_blas
 from .utils import libopenblas_paths
+from .utils import get_openblas_dll_path
 from .utils import make_long_windows_path
 from .utils import scipy
 from .utils import threadpool_info_from_subprocess
@@ -816,10 +817,10 @@ def test_windows_library_path_longer_than_max_path(tmp_path):
     Regression test inspired by the local repro in
     https://github.com/joblib/threadpoolctl/pull/189#issuecomment-2714235916
     """
-    if not libopenblas_paths:
-        pytest.skip("Requires numpy with shipped OpenBLAS on Windows")
+    src_dll = get_openblas_dll_path()
+    if src_dll is None:
+        pytest.skip("Requires OpenBLAS on Windows")
 
-    src_dll = next(iter(libopenblas_paths))
     dll_name = os.path.basename(src_dll)
     long_path = make_long_windows_path(tmp_path, dll_name, min_length=261)
     shutil.copy2(src_dll, long_path)
@@ -842,12 +843,12 @@ def test_windows_library_path_exceeds_internal_limit(tmp_path, monkeypatch):
     Regression test inspired by the local repro in
     https://github.com/joblib/threadpoolctl/pull/189#issuecomment-2714235916
     """
-    if not libopenblas_paths:
-        pytest.skip("Requires numpy with shipped OpenBLAS on Windows")
+    src_dll = get_openblas_dll_path()
+    if src_dll is None:
+        pytest.skip("Requires OpenBLAS on Windows")
 
     monkeypatch.setattr(threadpoolctl, "_WINDOWS_MAX_LIBRARY_PATH_LENGTH", 300)
 
-    src_dll = next(iter(libopenblas_paths))
     dll_name = "libopenblas_path_too_long.dll"
     long_path = make_long_windows_path(tmp_path, dll_name, min_length=301)
     shutil.copy2(src_dll, long_path)

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -875,6 +875,10 @@ def test_windows_library_path_longer_than_max_path(tmp_path):
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
+@pytest.mark.skipif(
+    threadpoolctl.dllist is not None,
+    reason="Python 3.14+ dllist does not apply the internal path length limit",
+)
 def test_windows_library_path_exceeds_internal_limit(tmp_path, monkeypatch):
     """Libraries with a path longer than the internal limit are ignored.
 

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -806,9 +806,13 @@ def test_threadpool_controller_repeated_init():
     """Stress-test repeated library discovery.
 
     Non-regression test for a Windows-specific problem where DLLs loaded or
-    unloaded concurrently during discovery could raise an OSError; see
-    https://github.com/joblib/threadpoolctl/issues/217
+    unloaded concurrently during discovery could raise an OSError. The failure
+    was originally reproduced after importing OpenCV on Windows conda-forge;
+    see https://github.com/joblib/threadpoolctl/issues/217
     """
+    pytest.importorskip("cv2")
+    import cv2  # noqa: F401
+
     for _ in range(100):
         ThreadpoolController()
 

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -620,6 +620,7 @@ def test_architecture():
     expected_openblas_architectures = (
         # XXX: add more as needed by CI or developer laptops
         "armv8",
+        "cooperlake",
         "haswell",
         "neoversen1",
         "prescott",  # see: https://github.com/xianyi/OpenBLAS/pull/3485

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -798,11 +798,12 @@ def test_custom_controller():
     assert ThreadpoolController().info() == original_info
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
-def test_threadpool_controller_repeated_init_on_windows():
-    """Stress-test Windows module enumeration for concurrent DLL load/unload.
+def test_threadpool_controller_repeated_init():
+    """Stress-test repeated library discovery.
 
-    Regression test for https://github.com/joblib/threadpoolctl/issues/217
+    Non-regression test for a Windows-specific problem where DLLs loaded or
+    unloaded concurrently during discovery could raise an OSError; see
+    https://github.com/joblib/threadpoolctl/issues/217
     """
     for _ in range(100):
         ThreadpoolController()
@@ -827,9 +828,7 @@ def test_windows_library_path_longer_than_max_path(tmp_path):
     expected_path = _realpath(str(long_path))
     openblas_info = ThreadpoolController().select(internal_api="openblas").info()
 
-    long_path_entries = [
-        info for info in openblas_info if len(info["filepath"]) > 260
-    ]
+    long_path_entries = [info for info in openblas_info if len(info["filepath"]) > 260]
     assert len(long_path_entries) >= 1
     assert any(
         _realpath(info["filepath"]) == expected_path for info in long_path_entries

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -1032,7 +1032,10 @@ def test_conda_blas_detection_after_import(module):
 
     info = threadpool_info_from_subprocess(module)
 
-    conda = which("conda") or which("micromamba") or which("mamba")
+    conda = shutil.which("conda") or shutil.which("micromamba") or shutil.which("mamba")
+    if conda is None:
+        pytest.skip("conda, micromamba, or mamba not found")
+
     conda_list_output = subprocess.check_output([conda, "list", "--json"], text=True)
     conda_list_items = json.loads(conda_list_output)
     blas_names_from_conda = [

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -4,6 +4,8 @@ import pytest
 import re
 import subprocess
 import sys
+import ctypes
+import shutil
 
 import threadpoolctl
 from threadpoolctl import threadpool_limits, threadpool_info
@@ -13,12 +15,8 @@ from threadpoolctl import _ALL_PREFIXES, _ALL_USER_APIS
 from .utils import cython_extensions_compiled
 from .utils import check_nested_prange_blas
 from .utils import libopenblas_paths
-from .utils import copy_and_load_dll
 from .utils import get_openblas_dll_path
-from .utils import LONG_PATH_OPENBLAS_DLL
 from .utils import make_long_windows_path
-from .utils import normalize_windows_path
-from .utils import TRUNCATED_PATH_OPENBLAS_DLL
 from .utils import scipy
 from .utils import threadpool_info_from_subprocess
 from .utils import select
@@ -811,7 +809,6 @@ def test_threadpool_controller_repeated_init():
     see https://github.com/joblib/threadpoolctl/issues/217
     """
     pytest.importorskip("cv2")
-    import cv2  # noqa: F401
 
     for _ in range(100):
         ThreadpoolController()
@@ -828,18 +825,37 @@ def test_windows_library_path_longer_than_max_path(tmp_path):
     if src_dll is None:
         pytest.skip("Requires OpenBLAS on Windows")
 
-    long_path = make_long_windows_path(tmp_path, LONG_PATH_OPENBLAS_DLL, min_length=261)
-    copy_and_load_dll(src_dll, long_path)
+    long_path = make_long_windows_path(
+        tmp_path, "libopenblas_long_path_test.dll", min_length=261
+    )
+    extended_path = os.path.abspath(str(long_path))
+    if not extended_path.startswith("\\\\?\\"):
+        if extended_path.startswith("\\\\"):
+            extended_path = "\\\\?\\UNC\\" + extended_path[2:]
+        else:
+            extended_path = "\\\\?\\" + extended_path
+    shutil.copy2(src_dll, extended_path)
+    ctypes.CDLL(extended_path)
 
-    expected_path = normalize_windows_path(long_path)
+    expected_path = os.path.abspath(str(long_path))
+    if expected_path.startswith("\\\\?\\"):
+        expected_path = expected_path[4:]
+        if expected_path.startswith("UNC\\"):
+            expected_path = "\\\\" + expected_path[4:]
+    expected_path = os.path.normcase(os.path.normpath(expected_path))
     openblas_info = ThreadpoolController().select(internal_api="openblas").info()
 
     long_path_entries = [info for info in openblas_info if len(info["filepath"]) > 260]
     assert len(long_path_entries) >= 1
-    assert any(
-        normalize_windows_path(info["filepath"]) == expected_path
-        for info in long_path_entries
-    )
+    normalized_filepaths = []
+    for info in long_path_entries:
+        filepath = info["filepath"]
+        if filepath.startswith("\\\\?\\"):
+            filepath = filepath[4:]
+            if filepath.startswith("UNC\\"):
+                filepath = "\\\\" + filepath[4:]
+        normalized_filepaths.append(os.path.normcase(os.path.normpath(filepath)))
+    assert expected_path in normalized_filepaths
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
@@ -856,17 +872,34 @@ def test_windows_library_path_exceeds_internal_limit(tmp_path, monkeypatch):
     monkeypatch.setattr(threadpoolctl, "_WINDOWS_MAX_LIBRARY_PATH_LENGTH", 300)
 
     long_path = make_long_windows_path(
-        tmp_path, TRUNCATED_PATH_OPENBLAS_DLL, min_length=400
+        tmp_path, "libopenblas_path_too_long.dll", min_length=400
     )
-    copy_and_load_dll(src_dll, long_path)
+    extended_path = os.path.abspath(str(long_path))
+    if not extended_path.startswith("\\\\?\\"):
+        if extended_path.startswith("\\\\"):
+            extended_path = "\\\\?\\UNC\\" + extended_path[2:]
+        else:
+            extended_path = "\\\\?\\" + extended_path
+    shutil.copy2(src_dll, extended_path)
+    ctypes.CDLL(extended_path)
 
-    expected_path = normalize_windows_path(long_path)
+    expected_path = os.path.abspath(str(long_path))
+    if expected_path.startswith("\\\\?\\"):
+        expected_path = expected_path[4:]
+        if expected_path.startswith("UNC\\"):
+            expected_path = "\\\\" + expected_path[4:]
+    expected_path = os.path.normcase(os.path.normpath(expected_path))
     with pytest.warns(RuntimeWarning, match="path too long"):
         info = ThreadpoolController().info()
 
-    filepaths = {
-        normalize_windows_path(entry["filepath"])
-        for entry in info
-        if "filepath" in entry
-    }
+    filepaths = set()
+    for entry in info:
+        if "filepath" not in entry:
+            continue
+        filepath = entry["filepath"]
+        if filepath.startswith("\\\\?\\"):
+            filepath = filepath[4:]
+            if filepath.startswith("UNC\\"):
+                filepath = "\\\\" + filepath[4:]
+        filepaths.add(os.path.normcase(os.path.normpath(filepath)))
     assert expected_path not in filepaths

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -2,10 +2,8 @@ import json
 import os
 import pytest
 import re
-import shutil
 import subprocess
 import sys
-import ctypes
 
 import threadpoolctl
 from threadpoolctl import threadpool_limits, threadpool_info
@@ -15,6 +13,7 @@ from threadpoolctl import _ALL_PREFIXES, _ALL_USER_APIS
 from .utils import cython_extensions_compiled
 from .utils import check_nested_prange_blas
 from .utils import libopenblas_paths
+from .utils import copy_and_load_dll
 from .utils import get_openblas_dll_path
 from .utils import make_long_windows_path
 from .utils import scipy
@@ -823,8 +822,7 @@ def test_windows_library_path_longer_than_max_path(tmp_path):
 
     dll_name = os.path.basename(src_dll)
     long_path = make_long_windows_path(tmp_path, dll_name, min_length=261)
-    shutil.copy2(src_dll, long_path)
-    ctypes.CDLL(str(long_path))
+    copy_and_load_dll(src_dll, long_path)
 
     expected_path = _realpath(str(long_path))
     openblas_info = ThreadpoolController().select(internal_api="openblas").info()
@@ -851,8 +849,7 @@ def test_windows_library_path_exceeds_internal_limit(tmp_path, monkeypatch):
 
     dll_name = "libopenblas_path_too_long.dll"
     long_path = make_long_windows_path(tmp_path, dll_name, min_length=301)
-    shutil.copy2(src_dll, long_path)
-    ctypes.CDLL(str(long_path))
+    copy_and_load_dll(src_dll, long_path)
 
     expected_path = _realpath(str(long_path))
     with pytest.warns(RuntimeWarning, match="path too long"):

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -2,16 +2,20 @@ import json
 import os
 import pytest
 import re
+import shutil
 import subprocess
 import sys
+import ctypes
 
+import threadpoolctl
 from threadpoolctl import threadpool_limits, threadpool_info
-from threadpoolctl import ThreadpoolController
+from threadpoolctl import ThreadpoolController, _realpath
 from threadpoolctl import _ALL_PREFIXES, _ALL_USER_APIS
 
 from .utils import cython_extensions_compiled
 from .utils import check_nested_prange_blas
 from .utils import libopenblas_paths
+from .utils import make_long_windows_path
 from .utils import scipy
 from .utils import threadpool_info_from_subprocess
 from .utils import select
@@ -792,3 +796,67 @@ def test_custom_controller():
         assert mylib_controller.num_threads == 1
 
     assert ThreadpoolController().info() == original_info
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
+def test_threadpool_controller_repeated_init_on_windows():
+    """Stress-test Windows module enumeration for concurrent DLL load/unload.
+
+    Regression test for https://github.com/joblib/threadpoolctl/issues/217
+    """
+    for _ in range(100):
+        ThreadpoolController()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
+def test_windows_library_path_longer_than_max_path(tmp_path):
+    """OpenBLAS loaded from a path longer than MAX_PATH is discovered.
+
+    Regression test inspired by the local repro in
+    https://github.com/joblib/threadpoolctl/pull/189#issuecomment-2714235916
+    """
+    if not libopenblas_paths:
+        pytest.skip("Requires numpy with shipped OpenBLAS on Windows")
+
+    src_dll = next(iter(libopenblas_paths))
+    dll_name = os.path.basename(src_dll)
+    long_path = make_long_windows_path(tmp_path, dll_name, min_length=261)
+    shutil.copy2(src_dll, long_path)
+    ctypes.CDLL(str(long_path))
+
+    expected_path = _realpath(str(long_path))
+    openblas_info = ThreadpoolController().select(internal_api="openblas").info()
+
+    long_path_entries = [
+        info for info in openblas_info if len(info["filepath"]) > 260
+    ]
+    assert len(long_path_entries) >= 1
+    assert any(
+        _realpath(info["filepath"]) == expected_path for info in long_path_entries
+    )
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
+def test_windows_library_path_exceeds_internal_limit(tmp_path, monkeypatch):
+    """Libraries with a path longer than the internal limit are ignored.
+
+    Regression test inspired by the local repro in
+    https://github.com/joblib/threadpoolctl/pull/189#issuecomment-2714235916
+    """
+    if not libopenblas_paths:
+        pytest.skip("Requires numpy with shipped OpenBLAS on Windows")
+
+    monkeypatch.setattr(threadpoolctl, "_WINDOWS_MAX_LIBRARY_PATH_LENGTH", 300)
+
+    src_dll = next(iter(libopenblas_paths))
+    dll_name = "libopenblas_path_too_long.dll"
+    long_path = make_long_windows_path(tmp_path, dll_name, min_length=301)
+    shutil.copy2(src_dll, long_path)
+    ctypes.CDLL(str(long_path))
+
+    expected_path = _realpath(str(long_path))
+    with pytest.warns(RuntimeWarning, match="path too long"):
+        info = ThreadpoolController().info()
+
+    filepaths = {_realpath(entry["filepath"]) for entry in info if "filepath" in entry}
+    assert expected_path not in filepaths

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,9 +18,17 @@ try:
     np.dot(np.ones(1000), np.ones(1000))
 
     libopenblas_patterns.append(os.path.join(np.__path__[0], ".libs", "libopenblas*"))
+    numpy_site_packages = os.path.dirname(np.__path__[0])
     libopenblas_patterns.append(
-        os.path.join(np.__path__[0], "numpy.libs", "libscipy_openblas*.dll")
+        os.path.join(numpy_site_packages, "numpy.libs", "libscipy_openblas*.dll")
     )
+    if sys.platform == "win32":
+        libopenblas_patterns.append(
+            os.path.join(sys.prefix, "Library", "bin", "openblas*.dll")
+        )
+        libopenblas_patterns.append(
+            os.path.join(sys.prefix, "Library", "bin", "libopenblas*.dll")
+        )
 except ImportError:
     pass
 
@@ -33,6 +41,10 @@ try:
 
     libopenblas_patterns.append(
         os.path.join(scipy.__path__[0], ".libs", "libopenblas*")
+    )
+    scipy_site_packages = os.path.dirname(scipy.__path__[0])
+    libopenblas_patterns.append(
+        os.path.join(scipy_site_packages, "scipy.libs", "libscipy_openblas*.dll")
     )
 except ImportError:
     scipy = None
@@ -90,6 +102,23 @@ def select(info, **kwargs):
     ]
 
     return selected_info
+
+
+def get_openblas_dll_path():
+    """Return a path to an OpenBLAS DLL that can be copied for Windows tests."""
+    if libopenblas_paths:
+        return next(iter(libopenblas_paths))
+
+    from threadpoolctl import ThreadpoolController
+
+    controllers = ThreadpoolController().select(internal_api="openblas").lib_controllers
+    if not controllers:
+        return None
+
+    filepath = controllers[0].filepath
+    if os.path.isfile(filepath):
+        return filepath
+    return None
 
 
 def make_long_windows_path(base_dir, filename, min_length=261):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -114,9 +114,7 @@ def get_openblas_dll_path():
             key=lambda path: (
                 0
                 if "libscipy_openblas" in os.path.basename(path).lower()
-                else 1
-                if "libopenblas" in os.path.basename(path).lower()
-                else 2
+                else 1 if "libopenblas" in os.path.basename(path).lower() else 2
             ),
         )[0]
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -109,7 +109,16 @@ def select(info, **kwargs):
 def get_openblas_dll_path():
     """Return a path to an OpenBLAS DLL that can be copied for Windows tests."""
     if libopenblas_paths:
-        return next(iter(libopenblas_paths))
+        return sorted(
+            libopenblas_paths,
+            key=lambda path: (
+                0
+                if "libscipy_openblas" in os.path.basename(path).lower()
+                else 1
+                if "libopenblas" in os.path.basename(path).lower()
+                else 2
+            ),
+        )[0]
 
     from threadpoolctl import ThreadpoolController
 
@@ -121,6 +130,20 @@ def get_openblas_dll_path():
     if os.path.isfile(filepath):
         return filepath
     return None
+
+
+def normalize_windows_path(path):
+    """Normalize Windows paths for stable comparisons in tests."""
+    path = os.path.abspath(str(path))
+    if path.startswith("\\\\?\\"):
+        path = path[4:]
+        if path.startswith("UNC\\"):
+            path = "\\\\" + path[4:]
+    return os.path.normcase(os.path.normpath(path))
+
+
+LONG_PATH_OPENBLAS_DLL = "libopenblas_long_path_test.dll"
+TRUNCATED_PATH_OPENBLAS_DLL = "libopenblas_path_too_long.dll"
 
 
 def make_long_windows_path(base_dir, filename, min_length=261):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,7 @@ import sys
 import threadpoolctl
 from glob import glob
 from os.path import dirname, normpath
+from pathlib import Path
 from subprocess import check_output
 
 # Path to shipped openblas for libraries such as numpy or scipy
@@ -17,6 +18,13 @@ try:
     np.dot(np.ones(1000), np.ones(1000))
 
     libopenblas_patterns.append(os.path.join(np.__path__[0], ".libs", "libopenblas*"))
+    if sys.platform == "win32":
+        libopenblas_patterns.append(
+            os.path.join(np.__path__[0], "numpy.libs", "libscipy_openblas*.dll")
+        )
+        libopenblas_patterns.append(
+            os.path.join(np.__path__[0], "numpy.libs", "libopenblas*.dll")
+        )
 except ImportError:
     pass
 
@@ -86,3 +94,19 @@ def select(info, **kwargs):
     ]
 
     return selected_info
+
+
+def make_long_windows_path(base_dir, filename, min_length=261):
+    """Nest padded directories under base_dir until base/.../filename >= min_length."""
+    padding_segments = ["a" * 100, "b" * 100, "c" * 100, "d" * 100]
+    current = Path(base_dir)
+    segment_index = 0
+    target = current / filename
+
+    while len(str(target)) < min_length:
+        current = current / padding_segments[segment_index % len(padding_segments)]
+        segment_index += 1
+        target = current / filename
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    return target

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,8 @@
-import os
 import json
+import os
 import sys
+import ctypes
+import shutil
 import threadpoolctl
 from glob import glob
 from os.path import dirname, normpath
@@ -135,3 +137,19 @@ def make_long_windows_path(base_dir, filename, min_length=261):
 
     target.parent.mkdir(parents=True, exist_ok=True)
     return target
+
+
+def to_extended_windows_path(path):
+    """Return an extended-length path for Windows APIs (> MAX_PATH)."""
+    path = os.path.abspath(str(path))
+    if path.startswith("\\\\?\\"):
+        return path
+    if path.startswith("\\\\"):
+        return "\\\\?\\UNC\\" + path[2:]
+    return "\\\\?\\" + path
+
+
+def copy_and_load_dll(src_dll, destination):
+    """Copy a DLL to destination and load it in the current process."""
+    shutil.copy2(src_dll, to_extended_windows_path(destination))
+    ctypes.CDLL(to_extended_windows_path(destination))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,13 +18,9 @@ try:
     np.dot(np.ones(1000), np.ones(1000))
 
     libopenblas_patterns.append(os.path.join(np.__path__[0], ".libs", "libopenblas*"))
-    if sys.platform == "win32":
-        libopenblas_patterns.append(
-            os.path.join(np.__path__[0], "numpy.libs", "libscipy_openblas*.dll")
-        )
-        libopenblas_patterns.append(
-            os.path.join(np.__path__[0], "numpy.libs", "libopenblas*.dll")
-        )
+    libopenblas_patterns.append(
+        os.path.join(np.__path__[0], "numpy.libs", "libscipy_openblas*.dll")
+    )
 except ImportError:
     pass
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -117,9 +117,11 @@ def get_openblas_dll_path():
             ),
         )[0]
 
-    controllers = threadpoolctl.ThreadpoolController().select(
-        internal_api="openblas"
-    ).lib_controllers
+    controllers = (
+        threadpoolctl.ThreadpoolController()
+        .select(internal_api="openblas")
+        .lib_controllers
+    )
     if not controllers:
         return None
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,6 @@
 import json
 import os
 import sys
-import ctypes
-import shutil
 import threadpoolctl
 from glob import glob
 from os.path import dirname, normpath
@@ -24,15 +22,16 @@ try:
     libopenblas_patterns.append(
         os.path.join(numpy_site_packages, "numpy.libs", "libscipy_openblas*.dll")
     )
-    if sys.platform == "win32":
-        libopenblas_patterns.append(
-            os.path.join(sys.prefix, "Library", "bin", "openblas*.dll")
-        )
-        libopenblas_patterns.append(
-            os.path.join(sys.prefix, "Library", "bin", "libopenblas*.dll")
-        )
 except ImportError:
     pass
+
+if sys.platform == "win32":
+    libopenblas_patterns.append(
+        os.path.join(sys.prefix, "Library", "bin", "openblas*.dll")
+    )
+    libopenblas_patterns.append(
+        os.path.join(sys.prefix, "Library", "bin", "libopenblas*.dll")
+    )
 
 
 try:
@@ -118,9 +117,9 @@ def get_openblas_dll_path():
             ),
         )[0]
 
-    from threadpoolctl import ThreadpoolController
-
-    controllers = ThreadpoolController().select(internal_api="openblas").lib_controllers
+    controllers = threadpoolctl.ThreadpoolController().select(
+        internal_api="openblas"
+    ).lib_controllers
     if not controllers:
         return None
 
@@ -128,20 +127,6 @@ def get_openblas_dll_path():
     if os.path.isfile(filepath):
         return filepath
     return None
-
-
-def normalize_windows_path(path):
-    """Normalize Windows paths for stable comparisons in tests."""
-    path = os.path.abspath(str(path))
-    if path.startswith("\\\\?\\"):
-        path = path[4:]
-        if path.startswith("UNC\\"):
-            path = "\\\\" + path[4:]
-    return os.path.normcase(os.path.normpath(path))
-
-
-LONG_PATH_OPENBLAS_DLL = "libopenblas_long_path_test.dll"
-TRUNCATED_PATH_OPENBLAS_DLL = "libopenblas_path_too_long.dll"
 
 
 def make_long_windows_path(base_dir, filename, min_length=261):
@@ -158,19 +143,3 @@ def make_long_windows_path(base_dir, filename, min_length=261):
 
     target.parent.mkdir(parents=True, exist_ok=True)
     return target
-
-
-def to_extended_windows_path(path):
-    """Return an extended-length path for Windows APIs (> MAX_PATH)."""
-    path = os.path.abspath(str(path))
-    if path.startswith("\\\\?\\"):
-        return path
-    if path.startswith("\\\\"):
-        return "\\\\?\\UNC\\" + path[2:]
-    return "\\\\?\\" + path
-
-
-def copy_and_load_dll(src_dll, destination):
-    """Copy a DLL to destination and load it in the current process."""
-    shutil.copy2(src_dll, to_extended_windows_path(destination))
-    ctypes.CDLL(to_extended_windows_path(destination))

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -1047,48 +1047,38 @@ class ThreadpoolController:
         """Loop through loaded libraries and return binders on supported ones
 
         This function is expected to work on windows system only.
-        """
-        PROCESS_QUERY_INFORMATION = 0x0400
-        PROCESS_VM_READ = 0x0010
 
+        Module discovery uses a snapshot-first strategy: when
+        ``CreateToolhelp32Snapshot`` succeeds, ``szExePath`` values are already
+        complete and shorter than ``MAX_PATH``. When the snapshot fails (for
+        example because a loaded DLL lives on a long path), enumeration falls
+        back to ``EnumProcessModulesEx`` and resolves paths with
+        ``GetModuleFileNameExW`` using a larger buffer.
+        """
         ps_api = self._get_windll("Psapi")
         kernel_32 = self._get_windll("kernel32")
         self._setup_windows_module_apis(ps_api, kernel_32)
 
-        h_process = kernel_32.OpenProcess(
-            PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, False, os.getpid()
-        )
-        if not h_process:  # pragma: no cover
-            raise OSError(f"Could not open PID {os.getpid()}")
+        h_process = kernel_32.GetCurrentProcess()
 
         # Allocate a buffer for long path names; see _WINDOWS_MAX_LIBRARY_PATH_LENGTH.
         max_path = _WINDOWS_MAX_LIBRARY_PATH_LENGTH
         path_buf = ctypes.create_unicode_buffer(max_path)
 
         try:
-            try:
-                modules = self._snapshot_loaded_modules(kernel_32)
-            except OSError:
-                modules = None
+            modules = self._snapshot_loaded_modules(kernel_32)
+        except OSError:
+            modules = None
 
-            if modules is not None:
-                for h_module, snapshot_path in modules:
-                    filepath = self._resolve_module_filepath(
-                        ps_api,
-                        h_process,
-                        h_module,
-                        snapshot_path,
-                        max_path,
-                        path_buf,
-                    )
-                    if filepath is not None:
-                        self._make_controller_from_path(filepath)
-            else:
-                self._find_libraries_with_enum_process_modules_ex(
-                    ps_api, h_process, max_path, path_buf
-                )
-        finally:
-            kernel_32.CloseHandle(h_process)
+        if modules is not None:
+            for _h_module, snapshot_path in modules:
+                filepath = self._snapshot_module_filepath(snapshot_path)
+                if filepath is not None:
+                    self._make_controller_from_path(filepath)
+        else:
+            self._find_libraries_with_enum_process_modules_ex(
+                ps_api, kernel_32, h_process, max_path, path_buf
+            )
 
     @classmethod
     def _setup_windows_module_apis(cls, ps_api, kernel_32):
@@ -1098,16 +1088,17 @@ class ThreadpoolController:
         if getattr(cls, "_windows_module_apis_configured", False):
             return
 
-        kernel_32.OpenProcess.argtypes = [DWORD, BOOL, DWORD]
-        kernel_32.OpenProcess.restype = HANDLE
-        kernel_32.CloseHandle.argtypes = [HANDLE]
-        kernel_32.CloseHandle.restype = BOOL
+        kernel_32.GetCurrentProcess.restype = HANDLE
         kernel_32.CreateToolhelp32Snapshot.argtypes = [DWORD, DWORD]
         kernel_32.CreateToolhelp32Snapshot.restype = HANDLE
         kernel_32.Module32FirstW.argtypes = [HANDLE, ctypes.c_void_p]
         kernel_32.Module32FirstW.restype = BOOL
         kernel_32.Module32NextW.argtypes = [HANDLE, ctypes.c_void_p]
         kernel_32.Module32NextW.restype = BOOL
+        kernel_32.GetModuleFileNameW.argtypes = [HMODULE, ctypes.c_wchar_p, DWORD]
+        kernel_32.GetModuleFileNameW.restype = DWORD
+        kernel_32.CloseHandle.argtypes = [HANDLE]
+        kernel_32.CloseHandle.restype = BOOL
 
         ps_api.EnumProcessModulesEx.argtypes = [
             HANDLE,
@@ -1192,17 +1183,40 @@ class ThreadpoolController:
 
         return modules
 
+    def _snapshot_module_filepath(self, snapshot_path):
+        """Return a snapshot module path, or None if it should be skipped."""
+        from ctypes.wintypes import MAX_PATH
+
+        if not snapshot_path:
+            return None
+
+        if len(snapshot_path) >= MAX_PATH - 1:  # pragma: no cover
+            warnings.warn(
+                "Could not get the full path of a dynamic library. This library "
+                "will be ignored and threadpoolctl might not be able to control or "
+                f"display information about all loaded libraries. Here's the "
+                f"truncated path: {snapshot_path!r}",
+                RuntimeWarning,
+            )
+            return None
+
+        return snapshot_path
+
     def _resolve_module_filepath(
         self,
         ps_api,
+        kernel_32,
         h_process,
         h_module,
-        snapshot_path,
         max_path,
         path_buf,
     ):
         """Return the full path for a module, or None if it should be skipped."""
         from ctypes.wintypes import MAX_PATH
+
+        n_size = kernel_32.GetModuleFileNameW(h_module, path_buf, MAX_PATH)
+        if n_size and n_size < MAX_PATH - 1:
+            return path_buf.value
 
         if ps_api.GetModuleFileNameExW(h_process, h_module, path_buf, max_path):
             filepath = path_buf.value
@@ -1217,21 +1231,10 @@ class ThreadpoolController:
                 return None
             return filepath
 
-        if snapshot_path is not None and len(snapshot_path) < MAX_PATH - 1:
-            return snapshot_path
-
-        if snapshot_path is not None:  # pragma: no cover
-            warnings.warn(
-                "Could not get the full path of a dynamic library. This library "
-                "will be ignored and threadpoolctl might not be able to control or "
-                f"display information about all loaded libraries. Here's the "
-                f"truncated path: {snapshot_path!r}",
-                RuntimeWarning,
-            )
         return None
 
     def _find_libraries_with_enum_process_modules_ex(
-        self, ps_api, h_process, max_path, path_buf
+        self, ps_api, kernel_32, h_process, max_path, path_buf
     ):
         """Fallback Windows module enumeration using EnumProcessModulesEx.
 
@@ -1265,9 +1268,9 @@ class ThreadpoolController:
         for h_module in map(HMODULE, buf[:count]):
             filepath = self._resolve_module_filepath(
                 ps_api,
+                kernel_32,
                 h_process,
                 h_module,
-                snapshot_path=None,
                 max_path=max_path,
                 path_buf=path_buf,
             )

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -1288,7 +1288,9 @@ class ThreadpoolController:
 
         Uses CreateToolhelp32Snapshot for an atomic view of loaded modules, which
         is more robust than EnumProcessModulesEx when DLLs are loaded or unloaded
-        concurrently.
+        concurrently. ``ERROR_BAD_LENGTH`` is retried a bounded number of times
+        (the documented transient race when the module list changes mid-snapshot)
+        and then raised as ``OSError`` so the caller can fall back.
         """
         from ctypes.wintypes import DWORD, HANDLE, MAX_PATH
 
@@ -1311,18 +1313,22 @@ class ThreadpoolController:
         ERROR_BAD_LENGTH = 0x0018
         ERROR_NO_MORE_FILES = 0x0012
         INVALID_HANDLE_VALUE = HANDLE(-1).value
+        max_snapshot_retries = 16
 
-        while True:
+        for _ in range(max_snapshot_retries):
             snap_handle = kernel_32.CreateToolhelp32Snapshot(
                 TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32, os.getpid()
             )
-            if snap_handle == INVALID_HANDLE_VALUE:
-                err = ctypes.get_last_error()
-                if err == ERROR_BAD_LENGTH:
-                    continue
-                msg = ctypes.FormatError(err).strip()
-                raise OSError(f"CreateToolhelp32Snapshot failed: {msg}")
-            break
+            if snap_handle != INVALID_HANDLE_VALUE:
+                break
+            err = ctypes.get_last_error()
+            if err == ERROR_BAD_LENGTH:
+                continue
+            msg = ctypes.FormatError(err).strip()
+            raise OSError(f"CreateToolhelp32Snapshot failed: {msg}")
+        else:
+            msg = ctypes.FormatError(ERROR_BAD_LENGTH).strip()
+            raise OSError(f"CreateToolhelp32Snapshot failed: {msg}")
 
         modules = []
         try:

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -1206,7 +1206,7 @@ class ThreadpoolController:
 
         if ps_api.GetModuleFileNameExW(h_process, h_module, path_buf, max_path):
             filepath = path_buf.value
-            if len(filepath) == max_path:  # pragma: no cover
+            if len(filepath) >= max_path - 1:  # pragma: no cover
                 warnings.warn(
                     "Could not get the full path of a dynamic library (path too "
                     "long). This library will be ignored and threadpoolctl might "

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -1212,15 +1212,17 @@ class ThreadpoolController:
 
         This function is expected to work on windows system only.
 
-        Module discovery uses a snapshot-first strategy: when
-        ``CreateToolhelp32Snapshot`` succeeds, ``szExePath`` values are already
-        complete and shorter than ``MAX_PATH``. When the snapshot fails (for
-        example because a loaded DLL lives on a long path), enumeration falls
-        back to ``EnumProcessModulesEx`` and resolves paths with
-        ``GetModuleFileNameExW`` using a larger buffer. The snapshot based
-        approach is more robust in case of concurrent DLL loading/unloading,
-        however it cannot handle long paths, hence the need for the fallback.
+        Module discovery uses a snapshot-first strategy:
+        ``CreateToolhelp32Snapshot`` provides an atomic list of loaded modules,
+        which is more robust than ``EnumProcessModulesEx`` under concurrent DLL
+        load/unload. Paths that fit in ``MODULEENTRY32W.szExePath`` (shorter
+        than ``MAX_PATH``) are used as-is. Truncated or empty snapshot paths
+        are resolved with ``GetModuleFileNameW`` and, when needed,
+        ``GetModuleFileNameExW`` with a larger buffer. If snapshot creation
+        fails, enumeration falls back to ``EnumProcessModulesEx``.
         """
+        from ctypes.wintypes import MAX_PATH
+
         ps_api = self._get_windll("Psapi")
         kernel_32 = self._get_windll("kernel32")
         self._setup_windows_module_apis(ps_api, kernel_32)
@@ -1237,8 +1239,18 @@ class ThreadpoolController:
             modules = None
 
         if modules is not None:
-            for _h_module, snapshot_path in modules:
-                filepath = self._snapshot_module_filepath(snapshot_path)
+            for h_module, snapshot_path in modules:
+                if snapshot_path and len(snapshot_path) < MAX_PATH - 1:
+                    filepath = snapshot_path
+                else:
+                    filepath = self._resolve_module_filepath(
+                        ps_api,
+                        kernel_32,
+                        h_process,
+                        h_module,
+                        max_path=max_path,
+                        path_buf=path_buf,
+                    )
                 if filepath is not None:
                     self._make_controller_from_path(filepath)
         else:
@@ -1354,25 +1366,6 @@ class ThreadpoolController:
             kernel_32.CloseHandle(snap_handle)
 
         return modules
-
-    def _snapshot_module_filepath(self, snapshot_path):
-        """Return a snapshot module path, or None if it should be skipped."""
-        from ctypes.wintypes import MAX_PATH
-
-        if not snapshot_path:
-            return None
-
-        if len(snapshot_path) >= MAX_PATH - 1:  # pragma: no cover
-            warnings.warn(
-                "Could not get the full path of a dynamic library. This library "
-                "will be ignored and threadpoolctl might not be able to control or "
-                f"display information about all loaded libraries. Here's the "
-                f"truncated path: {snapshot_path!r}",
-                RuntimeWarning,
-            )
-            return None
-
-        return snapshot_path
 
     def _resolve_module_filepath(
         self,

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -1251,7 +1251,7 @@ class ThreadpoolController:
             buf_size = ctypes.sizeof(buf)
             if not ps_api.EnumProcessModulesEx(
                 h_process,
-                ctypes.byref(buf),
+                buf,
                 buf_size,
                 ctypes.byref(needed),
                 LIST_LIBRARIES_ALL,

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -1053,7 +1053,9 @@ class ThreadpoolController:
         complete and shorter than ``MAX_PATH``. When the snapshot fails (for
         example because a loaded DLL lives on a long path), enumeration falls
         back to ``EnumProcessModulesEx`` and resolves paths with
-        ``GetModuleFileNameExW`` using a larger buffer.
+        ``GetModuleFileNameExW`` using a larger buffer. The snapshot based
+        approach is more robust in case of concurrent DLL loading/unloading,
+        however it cannot handle long paths, hence the need for the fallback.
         """
         ps_api = self._get_windll("Psapi")
         kernel_32 = self._get_windll("kernel32")

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -47,6 +47,10 @@ __all__ = [
 # disable it while under the scope of the outer OpenMP parallel section.
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "True")
 
+# Hard limit for Windows library paths resolved through GetModuleFileNameExW.
+# Kept below unlimited for security reasons; see CHANGES.md and PR #189.
+_WINDOWS_MAX_LIBRARY_PATH_LENGTH = 2600
+
 # Structure to cast the info on dynamically loaded library. See
 # https://linux.die.net/man/3/dl_iterate_phdr for more details.
 _SYSTEM_UINT = ctypes.c_uint64 if sys.maxsize > 2**32 else ctypes.c_uint32
@@ -969,7 +973,7 @@ class ThreadpoolController:
         if sys.platform == "darwin":
             self._find_libraries_with_dyld()
         elif sys.platform == "win32":
-            self._find_libraries_with_enum_process_module_ex()
+            self._find_libraries_on_windows()
         elif "pyodide" in sys.modules:
             self._find_libraries_pyodide()
         else:
@@ -1039,22 +1043,17 @@ class ThreadpoolController:
             # Store the library controller if it is supported and selected
             self._make_controller_from_path(filepath)
 
-    def _find_libraries_with_enum_process_module_ex(self):
+    def _find_libraries_on_windows(self):
         """Loop through loaded libraries and return binders on supported ones
 
         This function is expected to work on windows system only.
-        This code is adapted from code by Philipp Hagemeister @phihag available
-        at https://stackoverflow.com/questions/17474574
         """
-        from ctypes.wintypes import DWORD, HMODULE, MAX_PATH
-
         PROCESS_QUERY_INFORMATION = 0x0400
         PROCESS_VM_READ = 0x0010
 
-        LIST_LIBRARIES_ALL = 0x03
-
         ps_api = self._get_windll("Psapi")
         kernel_32 = self._get_windll("kernel32")
+        self._setup_windows_module_apis(ps_api, kernel_32)
 
         h_process = kernel_32.OpenProcess(
             PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, False, os.getpid()
@@ -1062,56 +1061,218 @@ class ThreadpoolController:
         if not h_process:  # pragma: no cover
             raise OSError(f"Could not open PID {os.getpid()}")
 
+        # Allocate a buffer for long path names; see _WINDOWS_MAX_LIBRARY_PATH_LENGTH.
+        max_path = _WINDOWS_MAX_LIBRARY_PATH_LENGTH
+        path_buf = ctypes.create_unicode_buffer(max_path)
+
         try:
-            buf_count = 256
-            needed = DWORD()
-            # Grow the buffer until it becomes large enough to hold all the
-            # module headers
-            while True:
-                buf = (HMODULE * buf_count)()
-                buf_size = ctypes.sizeof(buf)
-                if not ps_api.EnumProcessModulesEx(
-                    h_process,
-                    ctypes.byref(buf),
-                    buf_size,
-                    ctypes.byref(needed),
-                    LIST_LIBRARIES_ALL,
-                ):
-                    raise OSError("EnumProcessModulesEx failed")
-                if buf_size >= needed.value:
-                    break
-                buf_count = needed.value // (buf_size // buf_count)
+            try:
+                modules = self._snapshot_loaded_modules(kernel_32)
+            except OSError:
+                modules = None
 
-            count = needed.value // (buf_size // buf_count)
-            h_modules = map(HMODULE, buf[:count])
-
-            # Loop through all the module headers and get the library path
-            # Allocate a buffer for the path 10 times the size of MAX_PATH to take
-            # into account long path names.
-            max_path = 10 * MAX_PATH
-            buf = ctypes.create_unicode_buffer(max_path)
-            n_size = DWORD()
-            for h_module in h_modules:
-                # Get the path of the current module
-                if not ps_api.GetModuleFileNameExW(
-                    h_process, h_module, ctypes.byref(buf), ctypes.byref(n_size)
-                ):
-                    raise OSError("GetModuleFileNameEx failed")
-                filepath = buf.value
-
-                if len(filepath) == max_path:  # pragma: no cover
-                    warnings.warn(
-                        "Could not get the full path of a dynamic library (path too "
-                        "long). This library will be ignored and threadpoolctl might "
-                        "not be able to control or display information about all "
-                        f"loaded libraries. Here's the truncated path: {filepath!r}",
-                        RuntimeWarning,
+            if modules is not None:
+                for h_module, snapshot_path in modules:
+                    filepath = self._resolve_module_filepath(
+                        ps_api,
+                        h_process,
+                        h_module,
+                        snapshot_path,
+                        max_path,
+                        path_buf,
                     )
-                else:
-                    # Store the library controller if it is supported and selected
-                    self._make_controller_from_path(filepath)
+                    if filepath is not None:
+                        self._make_controller_from_path(filepath)
+            else:
+                self._find_libraries_with_enum_process_modules_ex(
+                    ps_api, h_process, max_path, path_buf
+                )
         finally:
             kernel_32.CloseHandle(h_process)
+
+    @classmethod
+    def _setup_windows_module_apis(cls, ps_api, kernel_32):
+        """Set ctypes signatures for Windows module enumeration APIs."""
+        from ctypes.wintypes import BOOL, DWORD, HANDLE, HMODULE
+
+        if getattr(cls, "_windows_module_apis_configured", False):
+            return
+
+        kernel_32.OpenProcess.argtypes = [DWORD, BOOL, DWORD]
+        kernel_32.OpenProcess.restype = HANDLE
+        kernel_32.CloseHandle.argtypes = [HANDLE]
+        kernel_32.CloseHandle.restype = BOOL
+        kernel_32.CreateToolhelp32Snapshot.argtypes = [DWORD, DWORD]
+        kernel_32.CreateToolhelp32Snapshot.restype = HANDLE
+        kernel_32.Module32FirstW.argtypes = [HANDLE, ctypes.c_void_p]
+        kernel_32.Module32FirstW.restype = BOOL
+        kernel_32.Module32NextW.argtypes = [HANDLE, ctypes.c_void_p]
+        kernel_32.Module32NextW.restype = BOOL
+
+        ps_api.EnumProcessModulesEx.argtypes = [
+            HANDLE,
+            ctypes.POINTER(HMODULE),
+            DWORD,
+            ctypes.POINTER(DWORD),
+            DWORD,
+        ]
+        ps_api.EnumProcessModulesEx.restype = BOOL
+        ps_api.GetModuleFileNameExW.argtypes = [
+            HANDLE,
+            HMODULE,
+            ctypes.c_wchar_p,
+            DWORD,
+        ]
+        ps_api.GetModuleFileNameExW.restype = BOOL
+
+        cls._windows_module_apis_configured = True
+
+    def _snapshot_loaded_modules(self, kernel_32):
+        """Return loaded modules as (hModule, snapshot_path) pairs.
+
+        Uses CreateToolhelp32Snapshot for an atomic view of loaded modules, which
+        is more robust than EnumProcessModulesEx when DLLs are loaded or unloaded
+        concurrently.
+        """
+        from ctypes.wintypes import DWORD, HANDLE, MAX_PATH
+
+        class MODULEENTRY32W(ctypes.Structure):
+            _fields_ = [
+                ("dwSize", DWORD),
+                ("th32ModuleID", DWORD),
+                ("th32ProcessID", DWORD),
+                ("GlblcntUsage", DWORD),
+                ("ProccntUsage", DWORD),
+                ("modBaseAddr", ctypes.POINTER(ctypes.c_byte)),
+                ("modBaseSize", DWORD),
+                ("hModule", HANDLE),
+                ("szModule", ctypes.c_wchar * 256),
+                ("szExePath", ctypes.c_wchar * MAX_PATH),
+            ]
+
+        TH32CS_SNAPMODULE = 0x00000008
+        TH32CS_SNAPMODULE32 = 0x00000010
+        ERROR_BAD_LENGTH = 0x0018
+        ERROR_NO_MORE_FILES = 0x0012
+        INVALID_HANDLE_VALUE = HANDLE(-1).value
+
+        while True:
+            snap_handle = kernel_32.CreateToolhelp32Snapshot(
+                TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32, os.getpid()
+            )
+            if snap_handle == INVALID_HANDLE_VALUE:
+                err = ctypes.get_last_error()
+                if err == ERROR_BAD_LENGTH:
+                    continue
+                msg = ctypes.FormatError(err).strip()
+                raise OSError(f"CreateToolhelp32Snapshot failed: {msg}")
+            break
+
+        modules = []
+        try:
+            lib_entry = MODULEENTRY32W()
+            lib_entry.dwSize = ctypes.sizeof(MODULEENTRY32W)
+            if not kernel_32.Module32FirstW(
+                snap_handle, ctypes.byref(lib_entry)
+            ):  # pragma: no cover
+                err = ctypes.get_last_error()
+                msg = ctypes.FormatError(err).strip()
+                raise OSError(f"Module32FirstW failed: {msg}")
+
+            while True:
+                modules.append((lib_entry.hModule, lib_entry.szExePath))
+                if not kernel_32.Module32NextW(snap_handle, ctypes.byref(lib_entry)):
+                    err = ctypes.get_last_error()
+                    if err != ERROR_NO_MORE_FILES:  # pragma: no cover
+                        msg = ctypes.FormatError(err).strip()
+                        raise OSError(f"Module32NextW failed: {msg}")
+                    break
+        finally:
+            kernel_32.CloseHandle(snap_handle)
+
+        return modules
+
+    def _resolve_module_filepath(
+        self,
+        ps_api,
+        h_process,
+        h_module,
+        snapshot_path,
+        max_path,
+        path_buf,
+    ):
+        """Return the full path for a module, or None if it should be skipped."""
+        from ctypes.wintypes import MAX_PATH
+
+        if ps_api.GetModuleFileNameExW(h_process, h_module, path_buf, max_path):
+            filepath = path_buf.value
+            if len(filepath) == max_path:  # pragma: no cover
+                warnings.warn(
+                    "Could not get the full path of a dynamic library (path too "
+                    "long). This library will be ignored and threadpoolctl might "
+                    "not be able to control or display information about all "
+                    f"loaded libraries. Here's the truncated path: {filepath!r}",
+                    RuntimeWarning,
+                )
+                return None
+            return filepath
+
+        if snapshot_path is not None and len(snapshot_path) < MAX_PATH - 1:
+            return snapshot_path
+
+        if snapshot_path is not None:  # pragma: no cover
+            warnings.warn(
+                "Could not get the full path of a dynamic library. This library "
+                "will be ignored and threadpoolctl might not be able to control or "
+                f"display information about all loaded libraries. Here's the "
+                f"truncated path: {snapshot_path!r}",
+                RuntimeWarning,
+            )
+        return None
+
+    def _find_libraries_with_enum_process_modules_ex(
+        self, ps_api, h_process, max_path, path_buf
+    ):
+        """Fallback Windows module enumeration using EnumProcessModulesEx.
+
+        This code is adapted from code by Philipp Hagemeister @phihag available
+        at https://stackoverflow.com/questions/17474574
+        """
+        from ctypes.wintypes import DWORD, HMODULE
+
+        LIST_LIBRARIES_ALL = 0x03
+
+        buf_count = 256
+        needed = DWORD()
+        # Grow the buffer until it becomes large enough to hold all the
+        # module headers
+        while True:
+            buf = (HMODULE * buf_count)()
+            buf_size = ctypes.sizeof(buf)
+            if not ps_api.EnumProcessModulesEx(
+                h_process,
+                ctypes.byref(buf),
+                buf_size,
+                ctypes.byref(needed),
+                LIST_LIBRARIES_ALL,
+            ):
+                raise OSError("EnumProcessModulesEx failed")
+            if buf_size >= needed.value:
+                break
+            buf_count = needed.value // (buf_size // buf_count)
+
+        count = needed.value // (buf_size // buf_count)
+        for h_module in map(HMODULE, buf[:count]):
+            filepath = self._resolve_module_filepath(
+                ps_api,
+                h_process,
+                h_module,
+                snapshot_path=None,
+                max_path=max_path,
+                path_buf=path_buf,
+            )
+            if filepath is not None:
+                self._make_controller_from_path(filepath)
 
     def _find_libraries_pyodide(self):
         """Pyodide specific implementation for finding loaded libraries.
@@ -1250,7 +1411,7 @@ class ThreadpoolController:
         """Load a windows DLL"""
         dll = cls._system_libraries.get(dll_name)
         if dll is None:
-            dll = ctypes.WinDLL(f"{dll_name}.dll")
+            dll = ctypes.WinDLL(f"{dll_name}.dll", use_last_error=True)
             cls._system_libraries[dll_name] = dll
         return dll
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -1140,11 +1140,6 @@ class ThreadpoolController:
             # mechanism that doesn't have these issues; since it's Linux, musl
             # works fine too.
             self._find_libraries_with_linux()
-        elif sys.platform == "win32":
-            # Prefer the snapshot-based enumerator over ctypes.util.dllist.
-            # CPython's dllist uses EnumProcessModules, which can raise
-            # OSError when DLLs are loaded or unloaded concurrently (#217).
-            self._find_libraries_on_windows()
         elif dllist is not None and sys.platform != "emscripten":
             # On Python 3.14+, this functionality is built-in. Once Python 3.13
             # is no longer supported by threadpoolctl, most of the equivalent
@@ -1152,9 +1147,18 @@ class ThreadpoolController:
             #
             # We don't use this on Linux since it uses dl_iterate_phdr
             # internally and so might still have deadlock issues.
-            self._find_libraries_with_python()
+            try:
+                self._find_libraries_with_python()
+            except OSError:
+                # CPython's Windows dllist uses EnumProcessModules, which can
+                # raise when DLLs are loaded or unloaded concurrently (#217).
+                if sys.platform != "win32":
+                    raise
+                self._find_libraries_on_windows()
         elif sys.platform == "darwin":
             self._find_libraries_with_dyld()
+        elif sys.platform == "win32":
+            self._find_libraries_on_windows()
         elif "pyodide" in sys.modules:
             self._find_libraries_pyodide()
         else:
@@ -1270,14 +1274,16 @@ class ThreadpoolController:
 
         This function is expected to work on windows system only.
 
-        Module discovery uses a snapshot-first strategy:
-        ``CreateToolhelp32Snapshot`` provides an atomic list of loaded modules,
-        which is more robust than ``EnumProcessModulesEx`` under concurrent DLL
-        load/unload. Paths that fit in ``MODULEENTRY32W.szExePath`` (shorter
-        than ``MAX_PATH``) are used as-is. Truncated or empty snapshot paths
-        are resolved with ``GetModuleFileNameW`` and, when needed,
-        ``GetModuleFileNameExW`` with a larger buffer. If snapshot creation
-        fails, enumeration falls back to ``EnumProcessModulesEx``.
+        Used when ``ctypes.util.dllist`` is unavailable (Python < 3.14) or when
+        that API raises ``OSError``. Module discovery uses a snapshot-first
+        strategy: ``CreateToolhelp32Snapshot`` provides an atomic list of loaded
+        modules, which is more robust than ``EnumProcessModulesEx`` under
+        concurrent DLL load/unload. Paths that fit in
+        ``MODULEENTRY32W.szExePath`` (shorter than ``MAX_PATH``) are used as-is.
+        Truncated or empty snapshot paths are resolved with
+        ``GetModuleFileNameW`` and, when needed, ``GetModuleFileNameExW`` with a
+        larger buffer. If snapshot creation fails, enumeration falls back to
+        ``EnumProcessModulesEx``.
         """
         from ctypes.wintypes import MAX_PATH
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -1147,14 +1147,7 @@ class ThreadpoolController:
             #
             # We don't use this on Linux since it uses dl_iterate_phdr
             # internally and so might still have deadlock issues.
-            try:
-                self._find_libraries_with_python()
-            except OSError:
-                # CPython's Windows dllist uses EnumProcessModules, which can
-                # raise when DLLs are loaded or unloaded concurrently (#217).
-                if sys.platform != "win32":
-                    raise
-                self._find_libraries_on_windows()
+            self._find_libraries_with_python()
         elif sys.platform == "darwin":
             self._find_libraries_with_dyld()
         elif sys.platform == "win32":
@@ -1274,8 +1267,8 @@ class ThreadpoolController:
 
         This function is expected to work on windows system only.
 
-        Used when ``ctypes.util.dllist`` is unavailable (Python < 3.14) or when
-        that API raises ``OSError``. Module discovery uses a snapshot-first
+        Used when ``ctypes.util.dllist`` is unavailable (Python < 3.14).
+        Module discovery uses a snapshot-first
         strategy: ``CreateToolhelp32Snapshot`` provides an atomic list of loaded
         modules, which is more robust than ``EnumProcessModulesEx`` under
         concurrent DLL load/unload. Paths that fit in


### PR DESCRIPTION
Fix #217

## Summary

- Fix intermittent `OSError("GetModuleFileNameEx failed")` on Windows when DLLs are loaded or unloaded during library discovery (reported with conda-forge OpenCV).
- Replace the two-phase `EnumProcessModulesEx` + `GetModuleFileNameExW` scan with a snapshot-first approach using `CreateToolhelp32Snapshot`, keeping long-path support via `GetModuleFileNameExW` and graceful per-module fallbacks.
- Add Windows integration tests for library paths longer than `MAX_PATH`, inspired by the local repro documented in https://github.com/joblib/threadpoolctl/pull/189#issuecomment-2714235916.

Closes https://github.com/joblib/threadpoolctl/issues/217

## Test plan

- [x] Windows CI (`py311_conda_forge_openblas`): new tests `test_windows_library_path_longer_than_max_path` and `test_windows_library_path_exceeds_internal_limit` pass
- [x] Windows CI: existing BLAS/OpenMP discovery tests still pass
- [x] Manual repro from issue #217 with conda-forge OpenCV:
  ```python
  import cv2
  from threadpoolctl import ThreadpoolController

  for _ in range(1000):
      ThreadpoolController()
  ```

## AI assistance disclosure

This pull request was prepared with assistance from an AI coding agent (Cursor / Claude).

Made with [Cursor](https://cursor.com)