### PR TITLE
FIX only warn about libomp/libiomp conflict on Linux

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,7 @@
 ===========
 
 - Only warn about simultaneous `libomp` and `libiomp` usage on Linux, where the
-  incompatibility is known to cause crashes. This avoids spurious test failures on
-  Windows CI jobs that load both libraries via conda-forge MKL stacks.
+  incompatibility is known to cause crashes.
 
 3.6.0 (2025-03-13)
 ==================

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+3.7.0 (TBD)
+===========
+
+- Only warn about simultaneous `libomp` and `libiomp` usage on Linux, where the
+  incompatibility is known to cause crashes. This avoids spurious test failures on
+  Windows CI jobs that load both libraries via conda-forge MKL stacks.
+
 3.6.0 (2025-03-13)
 ==================
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -1215,6 +1215,13 @@ class ThreadpoolController:
 
     def _warn_if_incompatible_openmp(self):
         """Raise a warning if llvm-OpenMP and intel-OpenMP are both loaded"""
+        if sys.platform != "linux":
+            # The incompatibility between libomp and libiomp is known to cause
+            # crashes on Linux. On other platforms, conda-forge may expose both
+            # libraries without the same runtime conflict (for instance when
+            # libiomp forwards to libomp on Windows).
+            return
+
         prefixes = [lib_controller.prefix for lib_controller in self.lib_controllers]
         msg = textwrap.dedent(
             """


### PR DESCRIPTION
Tentative fix Windows `pylatest_conda_forge_mkl` CI failure.

The conda-forge MKL environment loads both `libiomp` and `libomp`, triggering `RuntimeWarning` on every `ThreadpoolController` init. pytest runs with `-W error`, so tests fail.

The incompatibility between Intel and LLVM OpenMP runtimes is documented as a Linux-specific issue. This change skips the warning on non-Linux platforms.

Note: I am not sure if this is the right fix, but it's interesting to check if the crash is indeed Linux specific or not.

The alternative would be to change the dependencies in the CI config so that the Windows CI jobs that need MKL would not load clang's OpenMP runtime.