### PR TITLE
Use PEP 621 metadata to fix building with flit-core>=4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,16 @@
 [build-system]
-requires = ["flit_core >=2,<4"]
+requires = ["flit_core >=3.2,<5"]
 build-backend = "flit_core.buildapi"
 
-# TODO: replace the following section by the standard [project] section to be able
-# to use flit v4.
-[tool.flit.metadata]
-module = "threadpoolctl"
-author = "Thomas Moreau"
-author-email = "thomas.moreau.2010@gmail.com"
-home-page = "https://github.com/joblib/threadpoolctl"
-description-file = "README.md"
+[project]
+name = "threadpoolctl"
+author = [{name = "Thomas Moreau", email = "thomas.moreau.2010@gmail.com"}]
+readme = "README.md"
 requires-python = ">=3.9"
 license = "BSD-3-Clause"
+dynamic = ["version", "description"]
 classifiers = [
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -23,6 +19,9 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
+
+[project.url]
+homepage = "https://github.com/joblib/threadpoolctl"
 
 [tool.black]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "threadpoolctl"
-author = [{name = "Thomas Moreau", email = "thomas.moreau.2010@gmail.com"}]
+authors = [{name = "Thomas Moreau", email = "thomas.moreau.2010@gmail.com"}]
 readme = "README.md"
 requires-python = ">=3.9"
 license = "BSD-3-Clause"
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-[project.url]
+[project.urls]
 homepage = "https://github.com/joblib/threadpoolctl"
 
 [tool.black]


### PR DESCRIPTION
Followed the similar PR in cloudpickle: https://github.com/cloudpipe/cloudpickle/pull/598

Even if the version was pinned in `pyproject.toml` `flit<4`, the CI install a more recent `flit>=4` through `pip install -r dev-requirements.txt`.

See [build log](https://github.com/joblib/threadpoolctl/actions/runs/31449591996/job/93651026663). The CI has been failing since August 5, see [this](https://github.com/joblib/threadpoolctl/actions)