### PR TITLE
Use thread-local limiting APIs when possible, and fix deadlock

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,23 @@
 - Only warn about simultaneous `libomp` and `libiomp` usage on Linux, where the
   incompatibility is known to cause crashes.
 
+- Fixed a deadlock triggered by getting or setting MKL's number of threads from
+  parallel threads when using MKL with libiomp (Intel threading) on Linux.
+
+- Going forward, setting the number of threads will only have a thread-local
+  impact if feasible (for example, at minimum the underlying library must
+  support this option, and many don't.)
+
+- For MKL, setting the number of threads is now thread-local, i.e. limiting the
+  number of threads won't impact MKL's thread pool size when using MKL in other
+  Python threads.
+
+- For OpenBLAS compiled with OpenMP on Linux and macOS, setting the number of
+  threads is now thread-local, i.e. won't impact OpenBLAS thread pool size in
+  other Python threads. On Windows behavior is likely process-wide, but this may
+  depend on how OpenBLAS was compiled with OpenMP.
+
+
 3.6.0 (2025-03-13)
 ==================
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,20 +12,23 @@
 
 - Fixed a deadlock triggered by getting or setting MKL's number of threads from
   parallel threads when using MKL with libiomp (Intel threading) on Linux.
+  https://github.com/joblib/threadpoolctl/pull/228
 
 - Going forward, setting the number of threads will only have a thread-local
   impact if feasible (for example, at minimum the underlying library must
   support this option, and many don't.)
+  https://github.com/joblib/threadpoolctl/pull/228
 
 - For MKL, setting the number of threads is now thread-local, i.e. limiting the
   number of threads won't impact MKL's thread pool size when using MKL in other
   Python threads.
+  https://github.com/joblib/threadpoolctl/pull/228
 
 - For OpenBLAS compiled with OpenMP on Linux and macOS, setting the number of
   threads is now thread-local, i.e. won't impact OpenBLAS thread pool size in
   other Python threads. On Windows behavior is likely process-wide, but this may
   depend on how OpenBLAS was compiled with OpenMP.
-
+  https://github.com/joblib/threadpoolctl/pull/228
 
 3.6.0 (2025-03-13)
 ==================

--- a/conftest.py
+++ b/conftest.py
@@ -1,1 +1,1 @@
-collect_ignore = ["tests/_openmp_test_helper"]
+collect_ignore = ["tests/_openmp_test_helper", "tests/_limit_blas"]

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,5 +2,5 @@ flit
 coverage
 pytest
 pytest-cov
-cython
+cython<3.3
 setuptools

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,5 +2,5 @@ flit
 coverage
 pytest
 pytest-cov
-cython<3.3
+cython
 setuptools

--- a/tests/_limit_blas.py
+++ b/tests/_limit_blas.py
@@ -1,0 +1,21 @@
+# Used by test_setting_limit_on_thread_local_blas_api_is_actually_thread_local()
+
+from concurrent.futures import ThreadPoolExecutor
+from time import sleep
+import sys
+
+import numpy as np
+import threadpoolctl
+
+ARR = np.ones((1500, 1500))
+
+
+def in_thread(_):
+    with threadpoolctl.threadpool_limits(limits=int(sys.argv[1]), user_api="blas"):
+        ARR.dot(ARR)
+    # Make sure jobs are evenly distributed and don't end up in one thread.
+    sleep(0.01)
+
+
+with ThreadPoolExecutor(2) as pool:
+    list(pool.map(in_thread, range(2)))

--- a/tests/_limit_blas.py
+++ b/tests/_limit_blas.py
@@ -17,5 +17,6 @@ def in_thread(_):
     sleep(0.01)
 
 
-with ThreadPoolExecutor(2) as pool:
-    list(pool.map(in_thread, range(2)))
+if __name__ == '__main__':
+    with ThreadPoolExecutor(2) as pool:
+        list(pool.map(in_thread, range(2)))

--- a/tests/_limit_blas.py
+++ b/tests/_limit_blas.py
@@ -17,6 +17,6 @@ def in_thread(_):
     sleep(0.01)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     with ThreadPoolExecutor(2) as pool:
         list(pool.map(in_thread, range(2)))

--- a/tests/test_api_introspection.py
+++ b/tests/test_api_introspection.py
@@ -60,9 +60,6 @@ def test_determine_thread_limit_scope_processwide(default: int) -> None:
     assert _determine_thread_limit_scope(api.get, api.set) == "process"
 
 
-@pytest.mark.skipif(
-    sys.platform != "linux", reason="Non-Linux OpenMP might be different"
-)
 @pytest.mark.parametrize(
     ["select_filter", "expected_thread_limit_scope", "extra_check"],
     [
@@ -77,7 +74,12 @@ def test_determine_thread_limit_scope_processwide(default: int) -> None:
             # pthreads here.
             lambda lib: lib.threading_layer == "pthreads",
         ),
-        ({"user_api": "openmp"}, "current_thread", lambda _lib: True),
+        (
+            {"user_api": "openmp"},
+            "current_thread",
+            # Windows OpenMP is process-wide:
+            lambda _lib: sys.platform in ("linux", "darwin"),
+        ),
     ],
 )
 def test_api_scope(
@@ -94,9 +96,11 @@ def test_api_scope(
     if not controller.lib_controllers:
         pytest.skip(f"{select_filter} controller not found")
 
-    for lib in controller.lib_controllers:
-        if not extra_check(lib):
-            pytest.skip("extra check returned false")
+    libs = [lib for lib in controller.lib_controllers if extra_check(lib)]
+    if not libs:
+        pytest.skip("No libraries matched the requirements")
+
+    for lib in libs:
         assert (
             _determine_thread_limit_scope(lib.get_num_threads, lib.set_num_threads)
             == expected_thread_limit_scope

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -874,7 +874,7 @@ def test_setting_limit_on_thread_local_blas_api_is_actually_thread_local(
             ],
             stderr=subprocess.STDOUT,
         ).splitlines():
-            if b" clone3(" in line and b"CLONE_THREAD" in line:
+            if b"clone3(" in line and b"CLONE_THREAD" in line:
                 result += 1
         print(limit, result)
         return result

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -6,10 +6,12 @@ import pytest
 import re
 import subprocess
 import sys
+from typing import Callable
 
 from threadpoolctl import threadpool_limits, threadpool_info
-from threadpoolctl import ThreadpoolController
+from threadpoolctl import LibController, ThreadpoolController
 from threadpoolctl import _ALL_PREFIXES, _ALL_USER_APIS
+from threadpoolctl import _determine_thread_limit_scope
 
 from .utils import cython_extensions_compiled
 from .utils import check_nested_prange_blas
@@ -795,3 +797,39 @@ def test_custom_controller():
         assert mylib_controller.num_threads == 1
 
     assert ThreadpoolController().info() == original_info
+
+
+@pytest.mark.parametrize(
+    ["select_filter", "extra_check"],
+    [
+        (
+            {"internal_api": "openblas"},
+            lambda lib: (
+                lib.threading_layer == "openmp" and sys.platform in ("linux", "darwin")
+            ),
+        ),
+        (
+            {"internal_api": "mkl"},
+            lambda _lib: True,
+        ),
+    ],
+)
+def test_blas_setting_is_thread_local(
+    select_filter: dict[str, str],
+    extra_check: Callable[[LibController], bool],
+):
+    """
+    Setting the number of threads for mkl and OpenMP-based OpenBLAS uses a
+    thread-local setting API.
+    """
+    controller = ThreadpoolController().select(**select_filter)
+    if not controller.lib_controllers:
+        pytest.skip(f"{select_filter} controller not found")
+
+    libs = [lib for lib in controller.lib_controllers if extra_check(lib)]
+    if not libs:
+        pytest.skip("No libraries matched the requirements")
+
+    for lib in libs:
+        scope = _determine_thread_limit_scope(lib.get_num_threads, lib.set_num_threads)
+        assert scope == "current_thread"

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -881,6 +881,6 @@ def test_setting_limit_on_thread_local_blas_api_is_actually_thread_local(
         return result
 
     # _limit_blas runs BLAS operations in 2 Python threads, so by changing the
-    # BLAS limit from 2 to 5 we expect an extra 2 * (5 - 2) == 6 threads.
-    extra_threads = num_threads_created(5) - num_threads_created(2)
+    # BLAS limit from 1 to 4 we expect an extra 2 * (4 - 1) == 6 threads.
+    extra_threads = num_threads_created(4) - num_threads_created(1)
     assert extra_threads == 6

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -799,9 +799,8 @@ def test_custom_controller():
     assert ThreadpoolController().info() == original_info
 
 
-@pytest.mark.parametrize(
-    ["select_filter", "extra_check"],
-    [
+@pytest.fixture(
+    params=[
         (
             {"internal_api": "openblas"},
             lambda lib: (
@@ -812,16 +811,11 @@ def test_custom_controller():
             {"internal_api": "mkl"},
             lambda _lib: True,
         ),
-    ],
+    ]
 )
-def test_blas_setting_is_thread_local(
-    select_filter: dict[str, str],
-    extra_check: Callable[[LibController], bool],
-):
-    """
-    Setting the number of threads for mkl and OpenMP-based OpenBLAS uses a
-    thread-local setting API.
-    """
+def thread_local_blas_libs(request) -> list[LibController]:
+    """Create all LibControllers that use a thread-local setting."""
+    select_filter, extra_check = request.param
     controller = ThreadpoolController().select(**select_filter)
     if not controller.lib_controllers:
         pytest.skip(f"{select_filter} controller not found")
@@ -830,6 +824,18 @@ def test_blas_setting_is_thread_local(
     if not libs:
         pytest.skip("No libraries matched the requirements")
 
-    for lib in libs:
+    return libs
+
+
+def test_setting_limit_on_thread_local_blas_api_is_reported_as_thread_local(
+    thread_local_blas_libs: list[LibController],
+) -> None:
+    """
+    Setting the number of threads for libraries that support thread-local
+    setting API actually does so, according to the thread-number reporting API.
+
+    This doesn't check actual behavior, only reported behavior.
+    """
+    for lib in thread_local_blas_libs:
         scope = _determine_thread_limit_scope(lib.get_num_threads, lib.set_num_threads)
         assert scope == "current_thread"

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -877,7 +877,6 @@ def test_setting_limit_on_thread_local_blas_api_is_actually_thread_local(
         ).splitlines():
             if b"clone3(" in line and b"CLONE_THREAD" in line:
                 result += 1
-        print(limit, result)
         return result
 
     # _limit_blas runs BLAS operations in 2 Python threads, so by changing the

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -822,24 +822,29 @@ def parse_version(version: str) -> list[int]:
         ),
     ],
     # ids correspond to the params above:
-    ids=["openblas-openmp", "mkl"]
+    ids=["openblas-openmp", "mkl"],
 )
-def thread_local_blas_libs(request) -> list[LibController]:
+def thread_local_blas_lib(request) -> LibController:
     """Create all LibControllers that use a thread-local setting."""
     select_filter, extra_check = request.param
     controller = ThreadpoolController().select(**select_filter)
     if not controller.lib_controllers:
         pytest.skip(f"{select_filter} controller not found")
 
-    libs = [lib for lib in controller.lib_controllers if extra_check(lib)]
+    libs = [
+        lib
+        for lib in controller.lib_controllers
+        if extra_check(lib) and lib.internal_api == select_filter["internal_api"]
+    ]
     if not libs:
         pytest.skip("No libraries matched the requirements")
 
-    return libs
+    assert len(libs) == 1
+    return libs[0]
 
 
 def test_setting_limit_on_thread_local_blas_api_is_reported_as_thread_local(
-    thread_local_blas_libs: list[LibController],
+    thread_local_blas_lib: LibController,
 ) -> None:
     """
     Setting the number of threads for libraries that support thread-local
@@ -847,9 +852,9 @@ def test_setting_limit_on_thread_local_blas_api_is_reported_as_thread_local(
 
     This doesn't check actual behavior, only reported behavior.
     """
-    for lib in thread_local_blas_libs:
-        scope = _determine_thread_limit_scope(lib.get_num_threads, lib.set_num_threads)
-        assert scope == "current_thread"
+    lib = thread_local_blas_lib
+    scope = _determine_thread_limit_scope(lib.get_num_threads, lib.set_num_threads)
+    assert scope == "current_thread"
 
 
 @pytest.mark.skipif(
@@ -857,12 +862,32 @@ def test_setting_limit_on_thread_local_blas_api_is_reported_as_thread_local(
     reason="requires strace on Linux",
 )
 def test_setting_limit_on_thread_local_blas_api_is_actually_thread_local(
-    thread_local_blas_libs: list[LibController],
+    thread_local_blas_lib: LibController,
 ) -> None:
     """
     Setting the number of threads for libraries that support thread-local
     setting API actually does so.
     """
+
+    # The test script uses NumPy, there might be multiple BLAS in this test
+    # process, and we want to only run if _NumPy_ uses that library.
+    # So check that before proceeding.
+    output = json.loads(
+        subprocess.check_output(
+            [
+                "python",
+                "-c",
+                "import numpy, json, threadpoolctl; print(json.dumps(threadpoolctl.threadpool_info()))",
+            ]
+        )
+    )
+    found_correct_blas = False
+    for library in output:
+        if library["internal_api"] == thread_local_blas_lib.internal_api:
+            found_correct_blas = True
+            break
+    if not found_correct_blas:
+        pytest.skip("NumPy doesn't use the BLAS we want to test")
 
     def num_threads_created(limit: int) -> int:
         result = 0
@@ -885,5 +910,6 @@ def test_setting_limit_on_thread_local_blas_api_is_actually_thread_local(
 
     # _limit_blas runs BLAS operations in 2 Python threads, so by changing the
     # BLAS limit from 1 to 4 we expect an extra 2 * (4 - 1) == 6 threads.
-    extra_threads = num_threads_created(4) - num_threads_created(1)
-    assert extra_threads == 6
+    nmc_1 = num_threads_created(1)
+    nmc_4 = num_threads_created(4)
+    assert nmc_4 - nmc_1 == 6

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -6,7 +6,7 @@ import pytest
 import re
 import subprocess
 import sys
-from typing import Callable
+from shutil import which
 
 from threadpoolctl import threadpool_limits, threadpool_info
 from threadpoolctl import LibController, ThreadpoolController
@@ -799,12 +799,18 @@ def test_custom_controller():
     assert ThreadpoolController().info() == original_info
 
 
+def parse_version(version: str) -> list[int]:
+    return list(map(int, version.split(".")))
+
+
 @pytest.fixture(
     params=[
         (
             {"internal_api": "openblas"},
             lambda lib: (
-                lib.threading_layer == "openmp" and sys.platform in ("linux", "darwin")
+                lib.threading_layer == "openmp"
+                and sys.platform in ("linux", "darwin")
+                and parse_version(lib.version) >= parse_version("0.3.34")
             ),
         ),
         (
@@ -832,10 +838,48 @@ def test_setting_limit_on_thread_local_blas_api_is_reported_as_thread_local(
 ) -> None:
     """
     Setting the number of threads for libraries that support thread-local
-    setting API actually does so, according to the thread-number reporting API.
+    setting API is reported as doing so.
 
     This doesn't check actual behavior, only reported behavior.
     """
     for lib in thread_local_blas_libs:
         scope = _determine_thread_limit_scope(lib.get_num_threads, lib.set_num_threads)
         assert scope == "current_thread"
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux" or which("strace") is None,
+    reason="requires strace on Linux",
+)
+def test_setting_limit_on_thread_local_blas_api_is_actually_thread_local(
+    thread_local_blas_libs: list[LibController],
+) -> None:
+    """
+    Setting the number of threads for libraries that support thread-local
+    setting API actually does so.
+    """
+
+    def num_threads_created(limit: int) -> int:
+        result = 0
+        for line in subprocess.check_output(
+            [
+                "strace",
+                "-f",
+                "-e",
+                "clone3",
+                "python",
+                "-m",
+                "tests._limit_blas",
+                str(limit),
+            ],
+            stderr=subprocess.STDOUT,
+        ).splitlines():
+            if b" clone3(" in line and b"CLONE_THREAD" in line:
+                result += 1
+        print(limit, result)
+        return result
+
+    # _limit_blas runs BLAS operations in 2 Python threads, so by changing the
+    # BLAS limit from 2 to 9 we expect an extra 2 * (9 - 2) == 14 threads.
+    extra_threads = num_threads_created(9) - num_threads_created(2)
+    assert extra_threads == 14

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -881,6 +881,6 @@ def test_setting_limit_on_thread_local_blas_api_is_actually_thread_local(
         return result
 
     # _limit_blas runs BLAS operations in 2 Python threads, so by changing the
-    # BLAS limit from 2 to 9 we expect an extra 2 * (9 - 2) == 14 threads.
-    extra_threads = num_threads_created(9) - num_threads_created(2)
-    assert extra_threads == 14
+    # BLAS limit from 2 to 5 we expect an extra 2 * (5 - 2) == 6 threads.
+    extra_threads = num_threads_created(5) - num_threads_created(2)
+    assert extra_threads == 6

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -617,6 +617,7 @@ def test_architecture():
     expected_openblas_architectures = (
         # XXX: add more as needed by CI or developer laptops
         "armv8",
+        "barcelona",
         "cooperlake",
         "haswell",
         "neoversen1",

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -810,6 +810,8 @@ def parse_version(version: str) -> list[int]:
             {"internal_api": "openblas"},
             lambda lib: (
                 lib.threading_layer == "openmp"
+                # For Windows support, see
+                # https://github.com/joblib/threadpoolctl/issues/230
                 and sys.platform in ("linux", "darwin")
                 and parse_version(lib.version) >= parse_version("0.3.34")
             ),

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -820,7 +820,9 @@ def parse_version(version: str) -> list[int]:
             {"internal_api": "mkl"},
             lambda _lib: True,
         ),
-    ]
+    ],
+    # ids correspond to the params above:
+    ids=["openblas-openmp", "mkl"]
 )
 def thread_local_blas_libs(request) -> list[LibController]:
     """Create all LibControllers that use a thread-local setting."""

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -17,7 +17,7 @@ import sys
 import ctypes
 import itertools
 import textwrap
-from typing import final
+from typing import final, Any
 import warnings
 from ctypes.util import find_library
 from abc import ABC, abstractmethod
@@ -158,6 +158,24 @@ class LibController(ABC):
         return getattr(
             self.dynlib, f"{self._symbol_prefix}{name}{self._symbol_suffix}", None
         )
+
+
+class ThreadScopedController(ABC):
+    """
+    Provides a thread-number-setting API that only affects the current thread.
+
+    Useful in cases where there are two different APIs provided by the underlying library.
+    """
+
+    @abstractmethod
+    def set_num_threads_current_thread(self, num_threads: int) -> Any:
+        """
+        Set the maximum number of threads to use in library operations started
+        from the current thread.
+
+        Unlike ``set_num_threads``, which may have different scopes, this must
+        have thread-local scope only.
+        """
 
 
 class OpenBLASController(LibController):
@@ -423,7 +441,7 @@ class FlexiBLASController(LibController):
             raise RuntimeError(f"Failed to switch to backend {backend!r}.")
 
 
-class MKLController(LibController):
+class MKLController(LibController, ThreadScopedController):
     """Controller class for MKL"""
 
     user_api = "blas"
@@ -445,6 +463,12 @@ class MKLController(LibController):
 
     def set_num_threads(self, num_threads):
         set_func = getattr(self.dynlib, "MKL_Set_Num_Threads", lambda num_threads: None)
+        return set_func(num_threads)
+
+    def set_num_threads_current_thread(self, num_threads: int) -> Any:
+        set_func = getattr(
+            self.dynlib, "MKL_Set_Num_Threads_Local", lambda num_threads: None
+        )
         return set_func(num_threads)
 
     def get_version(self):

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -573,7 +573,9 @@ class MKLController(LibController):
         return get_func()
 
     def set_num_threads(self, num_threads):
-        set_func = getattr(self.dynlib, "MKL_Set_Num_Threads_Local", lambda: None)
+        set_func = getattr(
+            self.dynlib, "MKL_Set_Num_Threads_Local", lambda num_threads: None
+        )
         return set_func(num_threads)
 
     def get_version(self):

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -309,9 +309,9 @@ class OpenBLASController(LibController):
         # OpenMP API allows for current thread limiting when OpenMP has that
         # behavior. That is the case for libgomp, libomp, and libiomp, what you
         # would find on Linux or macOS. On Windows the Visual C++ OpenMP API is
-        # process-wide, unfortunately. Also worth knowing that in some
-        # versions, the OpenBLAS limiting API is broken when using OpenMP
-        # threading: https://github.com/OpenMathLib/OpenBLAS/issues/5806
+        # process-wide, unfortunately. Also worth knowing that before v0.3.34,
+        # the OpenBLAS limiting API is broken when using OpenMP threading:
+        # https://github.com/OpenMathLib/OpenBLAS/issues/5806
         if self.threading_layer == "openmp" and sys.platform in ("linux", "darwin"):
             symbol = "omp_set_num_threads"
         else:

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -143,7 +143,12 @@ class LibController(ABC):
 
     @abstractmethod
     def set_num_threads(self, num_threads):
-        """Set the maximum number of threads to use"""
+        """Set the maximum number of threads to use
+
+        If the underlying library supports multiple APIs where the choice is
+        between setting process-wide or current thread limits, the limiting API
+        should be the one that only applies to the current thread.
+        """
 
     @abstractmethod
     def get_version(self):
@@ -158,24 +163,6 @@ class LibController(ABC):
         return getattr(
             self.dynlib, f"{self._symbol_prefix}{name}{self._symbol_suffix}", None
         )
-
-
-class ThreadScopedController(ABC):
-    """
-    Provides a thread-number-setting API that only affects the current thread.
-
-    Useful in cases where there are two different APIs provided by the underlying library.
-    """
-
-    @abstractmethod
-    def set_num_threads_current_thread(self, num_threads: int) -> Any:
-        """
-        Set the maximum number of threads to use in library operations started
-        from the current thread.
-
-        Unlike ``set_num_threads``, which may have different scopes, this must
-        have thread-local scope only.
-        """
 
 
 class OpenBLASController(LibController):
@@ -441,7 +428,7 @@ class FlexiBLASController(LibController):
             raise RuntimeError(f"Failed to switch to backend {backend!r}.")
 
 
-class MKLController(LibController, ThreadScopedController):
+class MKLController(LibController):
     """Controller class for MKL"""
 
     user_api = "blas"
@@ -449,7 +436,7 @@ class MKLController(LibController, ThreadScopedController):
     filename_prefixes = ("libmkl_rt", "mkl_rt", "libblas")
     check_symbols = (
         "MKL_Get_Max_Threads",
-        "MKL_Set_Num_Threads",
+        "MKL_Set_Num_Threads_Local",
         "MKL_Get_Version_String",
         "MKL_Set_Threading_Layer",
     )
@@ -462,13 +449,7 @@ class MKLController(LibController, ThreadScopedController):
         return get_func()
 
     def set_num_threads(self, num_threads):
-        set_func = getattr(self.dynlib, "MKL_Set_Num_Threads", lambda num_threads: None)
-        return set_func(num_threads)
-
-    def set_num_threads_current_thread(self, num_threads: int) -> Any:
-        set_func = getattr(
-            self.dynlib, "MKL_Set_Num_Threads_Local", lambda num_threads: None
-        )
+        set_func = getattr(self.dynlib, "MKL_Set_Num_Threads_Local", lambda: None)
         return set_func(num_threads)
 
     def get_version(self):

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -1141,16 +1141,18 @@ class ThreadpoolController:
             )
             return []
 
+        filepaths = []
+
         # Callback function for `dl_iterate_phdr` which is called for every
-        # library loaded in the current process until it returns 1.
+        # library loaded in the current process until it returns 1. To minimize
+        # the potential for deadlocks (see #228), this code should not do
+        # anything that might result in reentrancy into the library, the dl
+        # system, or anything else.
         def match_library_callback(info, size, data):
             # Get the path of the current library
             filepath = info.contents.dlpi_name
             if filepath:
-                filepath = filepath.decode("utf-8")
-
-                # Store the library controller if it is supported and selected
-                self._make_controller_from_path(filepath)
+                filepaths.append(filepath)
             return 0
 
         c_func_signature = ctypes.CFUNCTYPE(
@@ -1163,6 +1165,12 @@ class ThreadpoolController:
 
         data = ctypes.c_char_p(b"")
         libc.dl_iterate_phdr(c_match_library_callback, data)
+
+        # Now that a list of filepaths is available, load the respective
+        # libraries:
+        for filepath in filepaths:
+            # Store the library controller if it is supported and selected
+            self._make_controller_from_path(filepath.decode("utf-8"))
 
     def _find_libraries_with_dyld(self):
         """Loop through loaded libraries and return binders on supported ones

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -193,13 +193,30 @@ class OpenBLASController(LibController):
         self.architecture = self._get_architecture()
 
     def get_num_threads(self):
-        get_num_threads_func = self._get_symbol("openblas_get_num_threads")
+        # See discussion in set_num_threads for details:
+        if self.threading_layer == "openmp" and sys.platform in ("linux", "darwin"):
+            symbol = "omp_get_max_threads"
+        else:
+            symbol = "openblas_get_num_threads"
+        get_num_threads_func = self._get_symbol(symbol)
         if get_num_threads_func is not None:
             return get_num_threads_func()
         return None
 
     def set_num_threads(self, num_threads):
-        set_num_threads_func = self._get_symbol("openblas_set_num_threads")
+        # The OpenBLAS limiting API is process-wide, and we want current thread
+        # limit if possible. When OpenBLAS is backed by OpenMP, using the
+        # OpenMP API allows for current thread limiting when OpenMP has that
+        # behavior. That is the case for libgomp, libomp, and libiomp, what you
+        # would find on Linux or macOS. On Windows the Visual C++ OpenMP API is
+        # process-wide, unfortunately. Also worth knowing that in some
+        # versions, the OpenBLAS limiting API is broken when using OpenMP
+        # threading: https://github.com/OpenMathLib/OpenBLAS/issues/5806
+        if self.threading_layer == "openmp" and sys.platform in ("linux", "darwin"):
+            symbol = "omp_set_num_threads"
+        else:
+            symbol = "openblas_set_num_threads"
+        set_num_threads_func = self._get_symbol(symbol)
         if set_num_threads_func is not None:
             return set_num_threads_func(num_threads)
         return None

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -242,9 +242,8 @@ class LibController(ABC):
     def set_num_threads(self, num_threads):
         """Set the maximum number of threads to use
 
-        If the underlying library supports multiple APIs where the choice is
-        between setting process-wide or current thread limits, the limiting API
-        should be the one that only applies to the current thread.
+        When possible, implementations of this method should choose a thread
+        limiting API that only applies to the current thread.
         """
 
     @abstractmethod

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -294,7 +294,7 @@ class OpenBLASController(LibController):
 
     def get_num_threads(self):
         # See discussion in set_num_threads for details:
-        if self.threading_layer == "openmp" and sys.platform in ("linux", "darwin"):
+        if self.threading_layer == "openmp":
             symbol = "omp_get_max_threads"
         else:
             symbol = "openblas_get_num_threads"
@@ -308,11 +308,16 @@ class OpenBLASController(LibController):
         # limit if possible. When OpenBLAS is backed by OpenMP, using the
         # OpenMP API allows for current thread limiting when OpenMP has that
         # behavior. That is the case for libgomp, libomp, and libiomp, what you
-        # would find on Linux or macOS. On Windows the Visual C++ OpenMP API is
-        # process-wide, unfortunately. Also worth knowing that before v0.3.34,
-        # the OpenBLAS limiting API is broken when using OpenMP threading:
+        # would find on Linux or macOS.
+        #
+        # On Windows the Visual C++ OpenMP API is process-wide, unfortunately,
+        # though this may be fixed if the /openmp:llvm flag is used:
+        # https://github.com/joblib/threadpoolctl/issues/230
+        #
+        # Also worth knowing that before v0.3.34, the OpenBLAS limiting API is
+        # broken when using OpenMP threading:
         # https://github.com/OpenMathLib/OpenBLAS/issues/5806
-        if self.threading_layer == "openmp" and sys.platform in ("linux", "darwin"):
+        if self.threading_layer == "openmp":
             symbol = "omp_set_num_threads"
         else:
             symbol = "openblas_set_num_threads"


### PR DESCRIPTION
Fixes #216 
Fixes #229 

I figured out a way to measure thread-creation that works on Linux, at least. Or that's the hope, anyway. (`ltrace` would be much more robust but I can't get it to work on Conda binaries).