### PR TITLE
CI Fix compilation issue with OpenMP inside conda env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,7 +239,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          ./continuous_integration/install.sh
+          source continuous_integration/install.sh
 
       # - name: Open SSH debug session
       #   uses: owenthereal/action-upterm@v1
@@ -251,7 +251,7 @@ jobs:
 
       - name: Test library
         run: |
-          ./continuous_integration/run_tests.sh
+          source continuous_integration/run_tests.sh
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,6 +241,13 @@ jobs:
         run: |
           bash -el continuous_integration/install.sh
 
+      - name: Open SSH debug session
+        uses: owenthereal/action-upterm@v1
+        if: ${{ always() }}
+        with:
+          limit-access-to-actor: true
+          wait-timeout-minutes: 60
+
       - name: Test library
         run: |
           bash -el continuous_integration/run_tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,14 +241,6 @@ jobs:
         run: |
           ./continuous_integration/install.sh
 
-      # - name: Open SSH debug session
-      #   uses: owenthereal/action-upterm@v1
-      #   if: ${{ failure() }}
-      #   with:
-      #     limit-access-to-actor: true
-      #     wait-timeout-minutes: 60
-      #     shell: bash --noprofile --norc
-
       - name: Test library
         run: |
           ./continuous_integration/run_tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,7 +214,7 @@ jobs:
       run:
         # Need to use this shell to get conda working properly.
         # See https://github.com/marketplace/actions/setup-miniconda#important
-        shell: ${{ matrix.os == 'windows-latest' && 'cmd /C CALL {0}' || 'bash -el {0}' }}
+        shell: 'bash -el {0}'
 
 
     steps:
@@ -239,7 +239,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          bash -e continuous_integration/install.sh
+          ./continuous_integration/install.sh
 
       # - name: Open SSH debug session
       #   uses: owenthereal/action-upterm@v1
@@ -251,7 +251,7 @@ jobs:
 
       - name: Test library
         run: |
-          bash -e continuous_integration/run_tests.sh
+          ./continuous_integration/run_tests.sh
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,7 +243,7 @@ jobs:
 
       - name: Open SSH debug session
         uses: owenthereal/action-upterm@v1
-        if: ${{ always() }}
+        if: ${{ failure() }}
         with:
           limit-access-to-actor: true
           wait-timeout-minutes: 60

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ on:
 # Cancel in-progress workflows when pushing
 # a new commit on the same branch
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,7 +239,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          source continuous_integration/install.sh
+          ./continuous_integration/install.sh
 
       # - name: Open SSH debug session
       #   uses: owenthereal/action-upterm@v1
@@ -251,7 +251,7 @@ jobs:
 
       - name: Test library
         run: |
-          source continuous_integration/run_tests.sh
+          ./continuous_integration/run_tests.sh
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,7 +239,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          bash continuous_integration/install.sh
+          ./continuous_integration/install.sh
 
       - name: Open SSH debug session
         uses: owenthereal/action-upterm@v1
@@ -251,7 +251,7 @@ jobs:
 
       - name: Test library
         run: |
-          bash continuous_integration/run_tests.sh
+          ./continuous_integration/run_tests.sh
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,6 +247,7 @@ jobs:
         with:
           limit-access-to-actor: true
           wait-timeout-minutes: 60
+          shell: bash --noprofile --norc
 
       - name: Test library
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,7 +239,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          bash -el continuous_integration/install.sh
+          bash continuous_integration/install.sh
 
       - name: Open SSH debug session
         uses: owenthereal/action-upterm@v1
@@ -251,7 +251,7 @@ jobs:
 
       - name: Test library
         run: |
-          bash -el continuous_integration/run_tests.sh
+          bash continuous_integration/run_tests.sh
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,19 +239,19 @@ jobs:
 
       - name: Install dependencies
         run: |
-          ./continuous_integration/install.sh
+          bash -e continuous_integration/install.sh
 
-      - name: Open SSH debug session
-        uses: owenthereal/action-upterm@v1
-        if: ${{ failure() }}
-        with:
-          limit-access-to-actor: true
-          wait-timeout-minutes: 60
-          shell: bash --noprofile --norc
+      # - name: Open SSH debug session
+      #   uses: owenthereal/action-upterm@v1
+      #   if: ${{ failure() }}
+      #   with:
+      #     limit-access-to-actor: true
+      #     wait-timeout-minutes: 60
+      #     shell: bash --noprofile --norc
 
       - name: Test library
         run: |
-          ./continuous_integration/run_tests.sh
+          bash -e continuous_integration/run_tests.sh
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/continuous_integration/build_test_ext.sh
+++ b/continuous_integration/build_test_ext.sh
@@ -12,6 +12,7 @@ fi
 
 pushd tests/_openmp_test_helper
 rm -rf *.c *.so *.dylib build/
+echo $PATH
 type -a clang
 python setup_inner.py build_ext -i
 python setup_outer.py build_ext -i

--- a/continuous_integration/build_test_ext.sh
+++ b/continuous_integration/build_test_ext.sh
@@ -12,7 +12,7 @@ fi
 
 pushd tests/_openmp_test_helper
 rm -rf *.c *.so *.dylib build/
-echo $PATH
+echo "$PATH"
 type -a clang
 python setup_inner.py build_ext -i
 python setup_outer.py build_ext -i

--- a/continuous_integration/build_test_ext.sh
+++ b/continuous_integration/build_test_ext.sh
@@ -12,6 +12,7 @@ fi
 
 pushd tests/_openmp_test_helper
 rm -rf *.c *.so *.dylib build/
+type -a clang
 python setup_inner.py build_ext -i
 python setup_outer.py build_ext -i
 

--- a/continuous_integration/build_test_ext.sh
+++ b/continuous_integration/build_test_ext.sh
@@ -12,8 +12,6 @@ fi
 
 pushd tests/_openmp_test_helper
 rm -rf *.c *.so *.dylib build/
-echo "$PATH"
-type -a clang
 python setup_inner.py build_ext -i
 python setup_outer.py build_ext -i
 

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -46,6 +46,7 @@ make_conda() {
         TO_INSTALL="$TO_INSTALL python-gil"
     fi
 
+    source "$CONDA/etc/profile.d/conda.sh"
     # prevent mixing conda channels
     conda config --set channel_priority strict
     conda config --add channels $CHANNEL
@@ -54,7 +55,6 @@ make_conda() {
     conda config --set solver libmamba
 
     conda create -n testenv -q --yes python=$PYTHON_VERSION $TO_INSTALL
-    source "$(conda info --base)/etc/profile.d/conda.sh"
     conda activate testenv
     echo "$PATH"
     type -a clang

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -46,7 +46,7 @@ make_conda() {
         TO_INSTALL="$TO_INSTALL python-gil"
     fi
 
-    # Need this before first conda command
+    # Need to source conda.sh before first conda command
     source "$CONDA/etc/profile.d/conda.sh"
     # prevent mixing conda channels
     conda config --set channel_priority strict
@@ -57,8 +57,6 @@ make_conda() {
 
     conda create -n testenv -q --yes python=$PYTHON_VERSION $TO_INSTALL
     conda activate testenv
-    echo "$PATH"
-    type -a clang
 }
 
 

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -54,6 +54,7 @@ make_conda() {
     conda config --set solver libmamba
 
     conda create -n testenv -q --yes python=$PYTHON_VERSION $TO_INSTALL
+    source "$(conda info --base)/etc/profile.d/conda.sh"
     conda activate testenv
     echo "$PATH"
     type -a clang

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -55,6 +55,8 @@ make_conda() {
 
     conda create -n testenv -q --yes python=$PYTHON_VERSION $TO_INSTALL
     conda activate testenv
+    echo "$PATH"
+    type -a clang
 }
 
 

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -46,6 +46,7 @@ make_conda() {
         TO_INSTALL="$TO_INSTALL python-gil"
     fi
 
+    # Need this before first conda command
     source "$CONDA/etc/profile.d/conda.sh"
     # prevent mixing conda channels
     conda config --set channel_priority strict

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -8,6 +8,7 @@ if [[ "$PACKAGER" == conda* ]] || [[ -z "$PACKAGER" ]]; then
     conda list
 elif [[ "$PACKAGER" == pip* ]]; then
     # we actually use conda to install the base environment:
+    source "$CONDA/etc/profile.d/conda.sh"
     conda activate testenv
     pip list
 elif [[ "$PACKAGER" == "ubuntu" ]]; then

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -21,7 +21,7 @@ fi
 python -m threadpoolctl -i numpy scipy.linalg tests._openmp_test_helper.openmp_helpers_inner
 
 # Introspect API scope:
-PYTHONPATH=. python -X faulthandler tests/empirical_scope_observation.py blas
-PYTHONPATH=. python -X faulthandler tests/empirical_scope_observation.py openmp
+PYTHONPATH=. python tests/empirical_scope_observation.py blas
+PYTHONPATH=. python tests/empirical_scope_observation.py openmp
 
 pytest -vlrxXs -W error -k "$TESTS" --junitxml=test_result.xml --cov=threadpoolctl --cov-report xml

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -3,6 +3,7 @@
 set -xe
 
 if [[ "$PACKAGER" == conda* ]] || [[ -z "$PACKAGER" ]]; then
+    source "$CONDA/etc/profile.d/conda.sh"
     conda activate testenv
     conda list
 elif [[ "$PACKAGER" == pip* ]]; then

--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -21,7 +21,7 @@ fi
 python -m threadpoolctl -i numpy scipy.linalg tests._openmp_test_helper.openmp_helpers_inner
 
 # Introspect API scope:
-PYTHONPATH=. python tests/empirical_scope_observation.py blas
-PYTHONPATH=. python tests/empirical_scope_observation.py openmp
+PYTHONPATH=. python -X faulthandler tests/empirical_scope_observation.py blas
+PYTHONPATH=. python -X faulthandler tests/empirical_scope_observation.py openmp
 
 pytest -vlrxXs -W error -k "$TESTS" --junitxml=test_result.xml --cov=threadpoolctl --cov-report xml


### PR DESCRIPTION
Fix https://github.com/joblib/threadpoolctl/issues/232

Here is a summary of my investigation:
- there is a bug on macOS for nested login shells https://github.com/conda/conda/issues/13500, the PATH is in the wrong order so system clang is picked instead of the `clang` symlink in the conda env. This cause the error about `clang` no knowing what to do with `-fopenmp` 
- minimally activated conda compilers is part of the picture https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/8795. Now what happens is that `CC` is not set when you install `compilers`. So `clang` is the compiler rather than the full conda compiler executable i.e. `x86_64-conda-<something>`. Before `CC` being set would hide the macOS bug from previous bullet point
- there is a number of combinatorial stuff that I tried before converging to something that works and doesn't seem to brittle/dodgy. I would rather avoid trying more things :wink:.
