### PR TITLE
FIX Fix OpenBLAS detection for conda package on Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,9 @@
   depend on how OpenBLAS was compiled with OpenMP.
   https://github.com/joblib/threadpoolctl/pull/228
 
+- Fix OpenBLAS detection for conda package on Windows
+  https://github.com/joblib/threadpoolctl/pull/240
+
 3.6.0 (2025-03-13)
 ==================
 

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -915,14 +915,21 @@ def test_setting_limit_on_thread_local_blas_api_is_actually_thread_local(
     assert nmc_4 - nmc_1 == 6
 
 
-@pytest.mark.skipif(
-    "atlas" in os.getenv("APT_BLAS", ""), reason="BLAS not detected with atlas"
-)
+@pytest.mark.skipif(os.getenv("CONDA_PREFIX") is None, reason="conda-specific test")
 @pytest.mark.parametrize("module", ["numpy", "scipy.linalg"])
-def test_blas_detection_after_import(module):
+def test_conda_blas_detection_after_import(module):
     pytest.importorskip(module)
 
+    conda_list_output = subprocess.check_output(
+        ["conda", "list", "--json"], text=True
+    )
+    conda_list_items = json.loads(conda_list_output)
+    blas_names_from_conda = [each["name"] for each in conda_list_items if "openblas" in each["name"] or "mkl" in each["name"]]
+    blas_names_from_conda = [each.replace("lib", "") for each in blas_names_from_conda]
     info = threadpool_info_from_subprocess(module)
 
     blas_info = select(info, user_api="blas")
     assert len(blas_info) > 0
+
+    blas_names_from_threadpoolctl = [each["internal_api"] for each in blas_info]
+    assert set(blas_names_from_threadpoolctl).issubset(blas_names_from_conda)

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -916,9 +916,9 @@ def test_setting_limit_on_thread_local_blas_api_is_actually_thread_local(
 
 
 @pytest.mark.parametrize("module", ["numpy", "scipy.linalg"])
-def test_openblas_detection_after_import(module):
+def test_blas_detection_after_import(module):
     info = threadpool_info_from_subprocess(module)
 
-    blas_info = select(info, internal_api="openblas")
+    blas_info = select(info, user_api="blas")
     assert len(blas_info) > 0
 

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -928,9 +928,7 @@ def test_conda_blas_detection_after_import(module):
     blas_names_from_conda = [
         each["name"]
         for each in conda_list_items
-        if any(
-            blas_lib in each["name"] for blas_lib in ["openblas", "mkl"]
-        )
+        if any(blas_lib in each["name"] for blas_lib in ["openblas", "mkl"])
     ]
     blas_names_from_conda = [each.replace("lib", "") for each in blas_names_from_conda]
 

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -913,3 +913,12 @@ def test_setting_limit_on_thread_local_blas_api_is_actually_thread_local(
     nmc_1 = num_threads_created(1)
     nmc_4 = num_threads_created(4)
     assert nmc_4 - nmc_1 == 6
+
+
+@pytest.mark.parametrize("module", ["numpy", "scipy.linalg"])
+def test_openblas_detection_after_import(module):
+    info = threadpool_info_from_subprocess(module)
+
+    blas_info = select(info, internal_api="openblas")
+    assert len(blas_info) > 0
+

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -915,7 +915,9 @@ def test_setting_limit_on_thread_local_blas_api_is_actually_thread_local(
     assert nmc_4 - nmc_1 == 6
 
 
-@pytest.mark.skipif("atlas" in os.getenv("APT_BLAS", ""), reason="BLAS not detected with atlas")
+@pytest.mark.skipif(
+    "atlas" in os.getenv("APT_BLAS", ""), reason="BLAS not detected with atlas"
+)
 @pytest.mark.parametrize("module", ["numpy", "scipy.linalg"])
 def test_blas_detection_after_import(module):
     info = threadpool_info_from_subprocess(module)

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -929,21 +929,21 @@ def test_conda_blas_detection_after_import(module):
         each["name"]
         for each in conda_list_items
         if any(
-            blas_lib in each["name"] for blas_lib in ["accelerate", "openblas", "mkl"]
+            blas_lib in each["name"] for blas_lib in ["openblas", "mkl"]
         )
     ]
     blas_names_from_conda = [each.replace("lib", "") for each in blas_names_from_conda]
 
-    if "accelerate" in blas_names_from_conda:
+    if "accelerate" in conda_list_output:
         pytest.skip("threadpoolctl does not know how to inspect Accelerate")
-        return
+
+    if not blas_names_from_conda:
+        pytest.skip(
+            f"{module} has been installed with pip, this is a conda-specific test"
+        )
 
     blas_info = select(info, user_api="blas")
     assert len(blas_info) > 0
-
-    if not blas_names_from_conda:
-        # 'module' has been installed with pip
-        return
 
     blas_names_from_threadpoolctl = [each["internal_api"] for each in blas_info]
     assert set(blas_names_from_threadpoolctl).issubset(blas_names_from_conda)

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -920,18 +920,30 @@ def test_setting_limit_on_thread_local_blas_api_is_actually_thread_local(
 def test_conda_blas_detection_after_import(module):
     pytest.importorskip(module)
 
-    conda_list_output = subprocess.check_output(["conda", "list", "--json"], text=True)
+    info = threadpool_info_from_subprocess(module)
+
+    conda = which("conda") or which("mamba") or which("micromamba")
+    conda_list_output = subprocess.check_output([conda, "list", "--json"], text=True)
     conda_list_items = json.loads(conda_list_output)
     blas_names_from_conda = [
         each["name"]
         for each in conda_list_items
-        if "openblas" in each["name"] or "mkl" in each["name"]
+        if any(
+            blas_lib in each["name"] for blas_lib in ["accelerate", "openblas", "mkl"]
+        )
     ]
     blas_names_from_conda = [each.replace("lib", "") for each in blas_names_from_conda]
-    info = threadpool_info_from_subprocess(module)
+
+    if "accelerate" in blas_names_from_conda:
+        pytest.skip("threadpoolctl does not know how to inspect Accelerate")
+        return
 
     blas_info = select(info, user_api="blas")
     assert len(blas_info) > 0
+
+    if not blas_names_from_conda:
+        # 'module' has been installed with pip
+        return
 
     blas_names_from_threadpoolctl = [each["internal_api"] for each in blas_info]
     assert set(blas_names_from_threadpoolctl).issubset(blas_names_from_conda)

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -915,6 +915,7 @@ def test_setting_limit_on_thread_local_blas_api_is_actually_thread_local(
     assert nmc_4 - nmc_1 == 6
 
 
+@pytest.mark.skipif("atlas" in os.getenv("APT_BLAS", ""), reason="BLAS not detected with atlas")
 @pytest.mark.parametrize("module", ["numpy", "scipy.linalg"])
 def test_blas_detection_after_import(module):
     info = threadpool_info_from_subprocess(module)

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -920,6 +920,8 @@ def test_setting_limit_on_thread_local_blas_api_is_actually_thread_local(
 )
 @pytest.mark.parametrize("module", ["numpy", "scipy.linalg"])
 def test_blas_detection_after_import(module):
+    pytest.importorskip(module)
+
     info = threadpool_info_from_subprocess(module)
 
     blas_info = select(info, user_api="blas")

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -921,4 +921,3 @@ def test_blas_detection_after_import(module):
 
     blas_info = select(info, user_api="blas")
     assert len(blas_info) > 0
-

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -920,11 +920,13 @@ def test_setting_limit_on_thread_local_blas_api_is_actually_thread_local(
 def test_conda_blas_detection_after_import(module):
     pytest.importorskip(module)
 
-    conda_list_output = subprocess.check_output(
-        ["conda", "list", "--json"], text=True
-    )
+    conda_list_output = subprocess.check_output(["conda", "list", "--json"], text=True)
     conda_list_items = json.loads(conda_list_output)
-    blas_names_from_conda = [each["name"] for each in conda_list_items if "openblas" in each["name"] or "mkl" in each["name"]]
+    blas_names_from_conda = [
+        each["name"]
+        for each in conda_list_items
+        if "openblas" in each["name"] or "mkl" in each["name"]
+    ]
     blas_names_from_conda = [each.replace("lib", "") for each in blas_names_from_conda]
     info = threadpool_info_from_subprocess(module)
 

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -943,5 +943,11 @@ def test_conda_blas_detection_after_import(module):
     blas_info = select(info, user_api="blas")
     assert len(blas_info) > 0
 
-    blas_names_from_threadpoolctl = [each["internal_api"] for each in blas_info]
+    # Flexiblas is built from source on our CI. At the time of writing, it is not
+    # available in the conda-forge channel.
+    blas_names_from_threadpoolctl = [
+        each["internal_api"]
+        for each in blas_info
+        if each["internal_api"] != "flexiblas"
+    ]
     assert set(blas_names_from_threadpoolctl).issubset(blas_names_from_conda)

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -922,7 +922,7 @@ def test_conda_blas_detection_after_import(module):
 
     info = threadpool_info_from_subprocess(module)
 
-    conda = which("conda") or which("mamba") or which("micromamba")
+    conda = which("conda") or which("micromamba") or which("mamba")
     conda_list_output = subprocess.check_output([conda, "list", "--json"], text=True)
     conda_list_items = json.loads(conda_list_output)
     blas_names_from_conda = [

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -270,7 +270,7 @@ class OpenBLASController(LibController):
         "libopenblas",
         "libblas",  # legacy conda-forge Windows shim, see _make_controller_from_path
         "libscipy_openblas",
-        "openblas", # Windows conda package use openblas.dll
+        "openblas",  # Windows conda package use openblas.dll
     )
 
     _symbol_prefixes = ("", "scipy_")

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -270,6 +270,7 @@ class OpenBLASController(LibController):
         "libopenblas",
         "libblas",  # legacy conda-forge Windows shim, see _make_controller_from_path
         "libscipy_openblas",
+        "openblas", # Windows conda package use openblas.dll
     )
 
     _symbol_prefixes = ("", "scipy_")


### PR DESCRIPTION
Fix https://github.com/joblib/threadpoolctl/issues/231

So OpenBLAS from conda use `openblas.dll`, which probably means we never detected OpenBLAS conda package? pip on Windows does use `libscipy_openblas` prefix.

