### PR TITLE
MNT Add faulthandler when running empirical observation script

### DIFF
--- a/continuous_integration/run_tests.sh
+++ b/continuous_integration/run_tests.sh
@@ -21,7 +21,7 @@ fi
 python -m threadpoolctl -i numpy scipy.linalg tests._openmp_test_helper.openmp_helpers_inner
 
 # Introspect API scope:
-PYTHONPATH=. python tests/empirical_scope_observation.py blas
-PYTHONPATH=. python tests/empirical_scope_observation.py openmp
+PYTHONPATH=. python -X faulthandler tests/empirical_scope_observation.py blas
+PYTHONPATH=. python -X faulthandler tests/empirical_scope_observation.py openmp
 
 pytest -vlrxXs -W error -k "$TESTS" --junitxml=test_result.xml --cov=threadpoolctl --cov-report xml


### PR DESCRIPTION
To try to give more info about Segmentation fault we have seen from time to time e.g. this [build log](https://github.com/joblib/threadpoolctl/actions/runs/34201397745/job/101980809164?pr=240) or https://github.com/joblib/threadpoolctl/pull/237#issuecomment-5560692775

```
+ python -m threadpoolctl -i numpy scipy.linalg tests._openmp_test_helper.openmp_helpers_inner
[
  {
    "user_api": "blas",
    "internal_api": "openblas",
    "num_threads": 4,
    "prefix": "openblas",
    "filepath": "C:\\Users\\runneradmin\\miniconda3\\envs\\testenv\\Library\\bin\\openblas.dll",
    "version": "0.3.34",
    "threading_layer": "pthreads",
    "architecture": "Zen",
    "thread_limit_scope": "process"
  },
  {
    "user_api": "openmp",
    "internal_api": "openmp",
    "num_threads": 4,
    "prefix": "vcomp",
    "filepath": "C:\\Users\\runneradmin\\miniconda3\\envs\\testenv\\vcomp140.dll",
    "version": null,
    "thread_limit_scope": "process"
  }
]
+ PYTHONPATH=.
+ python tests/empirical_scope_observation.py blas
./continuous_integration/run_tests.sh: line 24:   314 Segmentation fault         PYTHONPATH=. python tests/empirical_scope_observation.py blas
```