### PR TITLE
Avoid ctypes callbacks when listing libraries on Linux.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 3.7.0 (TBD)
 ===========
 
+- On Linux, loaded libraries are now enumerated from ``/proc/self/maps``
+  instead of a ``ctypes`` callback into ``dl_iterate_phdr``, and libc is
+  loaded with ``ctypes.CDLL(None)`` instead of ``ctypes.util.find_library``.
+  Both previous paths created libffi closures that can abort after ``os.fork()``
+  on some libffi builds (for example libffi 3.4.x with SELinux).
+  https://github.com/joblib/threadpoolctl/issues/225
+
 - Added the ability to check whether a limiting API affects just the current
   thread or the whole process. Mainly aimed at debugging and diagnostics, and
   somewhat unreliable, it is therefore enabled by default only for command-line

--- a/tests/test_threadpoolctl.py
+++ b/tests/test_threadpoolctl.py
@@ -12,6 +12,7 @@ from threadpoolctl import threadpool_limits, threadpool_info
 from threadpoolctl import LibController, ThreadpoolController
 from threadpoolctl import _ALL_PREFIXES, _ALL_USER_APIS
 from threadpoolctl import _determine_thread_limit_scope
+from threadpoolctl import _iter_mapped_filepaths
 
 from .utils import cython_extensions_compiled
 from .utils import check_nested_prange_blas
@@ -914,3 +915,50 @@ def test_setting_limit_on_thread_local_blas_api_is_actually_thread_local(
     nmc_1 = num_threads_created(1)
     nmc_4 = num_threads_created(4)
     assert nmc_4 - nmc_1 == 6
+
+
+def test_iter_mapped_filepaths():
+    maps = """\
+00400000-004c9000 r-xp 00000000 08:01 1234 /usr/bin/python3
+7f001000-7f002000 r-xp 00000000 08:01 5678 /usr/lib/libopenblas.so.0
+7f002000-7f003000 r--p 00001000 08:01 5678 /usr/lib/libopenblas.so.0
+7f003000-7f004000 rw-p 00002000 08:01 5678 /usr/lib/libopenblas.so.0
+7fff0000-7fff1000 rw-p 00000000 00:00 0    [stack]
+7fff2000-7fff3000 r-xp 00000000 00:00 0    [vdso]
+7f004000-7f005000 r-xp 00000000 08:01 9    /tmp/gone.so (deleted)
+"""
+    assert list(_iter_mapped_filepaths(maps)) == [
+        "/usr/bin/python3",
+        "/usr/lib/libopenblas.so.0",
+        "/tmp/gone.so",
+    ]
+
+
+def test_importing_threadpoolctl_does_not_load_ctypes_util():
+    # ctypes.util on CPython 3.13+ Linux allocates a process-lifetime CFUNCTYPE
+    # callback; importing it in the parent is enough to abort after fork with
+    # some libffi builds. See https://github.com/joblib/threadpoolctl/issues/225.
+    path = os.path.dirname(os.path.dirname(__file__))
+    env = os.environ.copy()
+    env["PYTHONPATH"] = path + os.pathsep + env.get("PYTHONPATH", "")
+    script = """
+import sys
+import threadpoolctl
+assert "ctypes.util" not in sys.modules, sorted(sys.modules)
+threadpoolctl.threadpool_info()
+assert "ctypes.util" not in sys.modules
+"""
+    subprocess.check_call([sys.executable, "-c", script], env=env)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"), reason="requires /proc/self/maps"
+)
+def test_linux_library_discovery_uses_proc_maps():
+    controller = ThreadpoolController()
+    assert controller._find_libraries_with_proc_maps() is True
+    maps = open("/proc/self/maps", encoding="utf-8", errors="surrogateescape").read()
+    mapped = set(_iter_mapped_filepaths(maps))
+    real_mapped = {os.path.realpath(p) for p in mapped}
+    for lib_controller in controller.lib_controllers:
+        assert lib_controller.filepath in real_mapped

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -20,7 +20,6 @@ import textwrap
 from threading import Thread
 from typing import Callable, Literal, final
 import warnings
-from ctypes.util import find_library
 from abc import ABC, abstractmethod
 from functools import lru_cache
 from contextlib import ContextDecorator
@@ -678,6 +677,30 @@ def _format_docstring(*args, **kwargs):
     return decorator
 
 
+def _iter_mapped_filepaths(maps_text):
+    """Yield unique file-backed paths from a ``/proc/*/maps`` dump.
+
+    Each mapped object typically appears several times (r-x, r--, rw-).
+    Anonymous mappings and kernel pseudo-files (``[heap]``, ``[vdso]``, ...)
+    are skipped.
+    """
+    seen = set()
+    for line in maps_text.splitlines():
+        # address perms offset dev inode [pathname]
+        parts = line.split(None, 5)
+        if len(parts) < 6:
+            continue
+        pathname = parts[5]
+        if pathname.startswith("[") or pathname.startswith("anon_inode:"):
+            continue
+        if pathname.endswith(" (deleted)"):
+            pathname = pathname[: -len(" (deleted)")]
+        if pathname in seen:
+            continue
+        seen.add(pathname)
+        yield pathname
+
+
 @lru_cache(maxsize=10000)
 def _realpath(filepath):
     """Small caching wrapper around os.path.realpath to limit system calls"""
@@ -1127,8 +1150,34 @@ class ThreadpoolController:
             self._find_libraries_with_enum_process_module_ex()
         elif "pyodide" in sys.modules:
             self._find_libraries_pyodide()
+        elif self._find_libraries_with_proc_maps():
+            return
         else:
             self._find_libraries_with_dl_iterate_phdr()
+
+    def _find_libraries_with_proc_maps(self):
+        """Enumerate loaded shared objects from ``/proc/self/maps``.
+
+        This is the preferred path on Linux: it does not create a
+        ``ctypes.CFUNCTYPE`` callback, whose libffi trampoline is allocated
+        from a ``MAP_SHARED`` memfd on some builds (SELinux / W^X) and is not
+        fork-safe. See https://github.com/joblib/threadpoolctl/issues/225.
+
+        Returns True if the maps file was read, even when no supported library
+        was found. Returns False when ``/proc`` is unavailable so callers can
+        fall back to ``dl_iterate_phdr``.
+        """
+        try:
+            with open(
+                "/proc/self/maps", encoding="utf-8", errors="surrogateescape"
+            ) as f:
+                maps_text = f.read()
+        except OSError:
+            return False
+
+        for filepath in _iter_mapped_filepaths(maps_text):
+            self._make_controller_from_path(filepath)
+        return True
 
     def _find_libraries_with_dl_iterate_phdr(self):
         """Loop through loaded libraries and return binders on supported ones
@@ -1403,13 +1452,15 @@ class ThreadpoolController:
         """Load the lib-C for unix systems."""
         libc = cls._system_libraries.get("libc")
         if libc is None:
-            # Remark: If libc is statically linked or if Python is linked against an
-            # alternative implementation of libc like musl, find_library will return
-            # None and CDLL will load the main program itself which should contain the
-            # libc symbols. We still name it libc for convenience.
-            # If the main program does not contain the libc symbols, it's ok because
-            # we check their presence later anyway.
-            libc = ctypes.CDLL(find_library("c"), mode=_RTLD_NOLOAD)
+            # Use the main program (dlopen(NULL)) rather than ctypes.util.find_library.
+            # Importing ctypes.util on CPython 3.13+ Linux creates a process-lifetime
+            # CFUNCTYPE callback for dllist(); that libffi closure is not fork-safe
+            # on some libffi builds. See
+            # https://github.com/joblib/threadpoolctl/issues/225.
+            # If libc is statically linked or Python is linked against musl, the
+            # main program still exports the libc symbols we need. If it does not,
+            # we check for those symbols later anyway.
+            libc = ctypes.CDLL(None, mode=_RTLD_NOLOAD)
             cls._system_libraries["libc"] = libc
         return libc
 

--- a/threadpoolctl.py
+++ b/threadpoolctl.py
@@ -24,7 +24,6 @@ from abc import ABC, abstractmethod
 from functools import lru_cache
 from contextlib import ContextDecorator
 
-
 __version__ = "3.7.0.dev0"
 __all__ = [
     "threadpool_limits",


### PR DESCRIPTION
Workaround for #225 on some system:

Importing ctypes.util or using CFUNCTYPE with dl_iterate_phdr creates libffi closures that can abort after fork on some Linux libffi builds. Enumerate libraries from /proc/self/maps and load libc via CDLL(None).

Disclaimer: this PR was vibecoded although I did ask the agent to use a container to check that it actually workaround the problem on AlmaLinux 9.8 (Olive Jaguar) with libffi-3.4.2-8.el9.

Still, I find the extra complexity in threadpoolctl not justified. I would rather wait for upstream ctypes to fix the problem or wait for all impacted linux distributions to upgrade to a newer libffi.